### PR TITLE
feat(auth): add per-user task isolation

### DIFF
--- a/drizzle/0004_even_red_shift.sql
+++ b/drizzle/0004_even_red_shift.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `tasks` ADD `user_id` integer NOT NULL DEFAULT 1 REFERENCES users(id) ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE `automations` ADD `user_id` integer NOT NULL DEFAULT 1 REFERENCES users(id) ON DELETE CASCADE;--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_category_colors` (
+	`user_id` integer NOT NULL,
+	`category` text NOT NULL,
+	`color` text NOT NULL,
+	PRIMARY KEY(`user_id`, `category`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT INTO `__new_category_colors`("user_id", "category", "color") SELECT 1, "category", "color" FROM `category_colors`;--> statement-breakpoint
+DROP TABLE `category_colors`;--> statement-breakpoint
+ALTER TABLE `__new_category_colors` RENAME TO `category_colors`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,501 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b0bab8bc-4b02-4069-9b50-aa344360868d",
+  "prevId": "9eff3f70-3ac1-4616-8512-22d1cf7293dd",
+  "tables": {
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automations_user_id_users_id_fk": {
+          "name": "automations_user_id_users_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category_colors": {
+      "name": "category_colors",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_colors_user_id_users_id_fk": {
+          "name": "category_colors_user_id_users_id_fk",
+          "tableFrom": "category_colors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "category_colors_user_id_category_pk": {
+          "columns": [
+            "user_id",
+            "category"
+          ],
+          "name": "category_colors_user_id_category_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_dependencies": {
+      "name": "task_dependencies",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depends_on_id": {
+          "name": "depends_on_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_dependencies_task_id_tasks_id_fk": {
+          "name": "task_dependencies_task_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependencies_depends_on_id_tasks_id_fk": {
+          "name": "task_dependencies_depends_on_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "depends_on_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_dependencies_task_id_depends_on_id_pk": {
+          "columns": [
+            "task_id",
+            "depends_on_id"
+          ],
+          "name": "task_dependencies_task_id_depends_on_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recur_mode": {
+          "name": "recur_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_api_key_unique": {
+          "name": "users_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774229762414,
       "tag": "0003_flippant_cyclops",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1774234338600,
+      "tag": "0004_even_red_shift",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { createUser, verifyPassword } from "../src/core/auth";
 import { addDependency } from "../src/core/dag";
 import { createTask, updateTask } from "../src/core/task";
 import * as schema from "../src/db/schema";
@@ -16,6 +17,10 @@ const db = drizzle(sqlite, { schema });
 
 migrate(db, { migrationsFolder: "./drizzle" });
 
+let user = verifyPassword(db, "barrett", "demo");
+if (!user) user = createUser(db, "barrett", "demo");
+const userId = user.id;
+
 const now = new Date();
 function daysFromNow(n: number): string {
   const d = new Date(now);
@@ -23,7 +28,7 @@ function daysFromNow(n: number): string {
   return d.toISOString();
 }
 
-const taxes = createTask(db, {
+const taxes = createTask(db, userId, {
   description: "File 2025 federal tax return",
   category: "Life Admin",
   priority: 3,
@@ -31,7 +36,7 @@ const taxes = createTask(db, {
   status: "wip",
 });
 
-const stateReturn = createTask(db, {
+const stateReturn = createTask(db, userId, {
   description: "File TX + NY state tax returns",
   category: "Life Admin",
   priority: 2,
@@ -39,35 +44,35 @@ const stateReturn = createTask(db, {
 });
 addDependency(db, stateReturn.id, taxes.id);
 
-createTask(db, {
+createTask(db, userId, {
   description: "Submit Roth IRA contribution for 2025",
   category: "Life Admin",
   priority: 2,
   due: daysFromNow(21),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Review health insurance options for IMC",
   category: "Life Admin",
   priority: 1,
   due: daysFromNow(60),
 });
 
-const canolaRefactor = createTask(db, {
+const canolaRefactor = createTask(db, userId, {
   description: "Refactor canola.nvim highlight module",
   category: "Open Source",
   priority: 2,
   status: "wip",
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Fix diagnostic range off-by-one in canola.nvim",
   category: "Open Source",
   priority: 3,
   due: daysFromNow(3),
 });
 
-const canolaDocs = createTask(db, {
+const canolaDocs = createTask(db, userId, {
   description: "Write canola.nvim migration guide from oil.nvim",
   category: "Open Source",
   priority: 1,
@@ -75,7 +80,7 @@ const canolaDocs = createTask(db, {
 });
 addDependency(db, canolaDocs.id, canolaRefactor.id);
 
-createTask(db, {
+createTask(db, userId, {
   description: "Triage pending.nvim issues",
   category: "Open Source",
   priority: 1,
@@ -84,7 +89,7 @@ createTask(db, {
   recurMode: "scheduled",
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Review open PRs on GitHub repos",
   category: "Open Source",
   priority: 2,
@@ -93,7 +98,7 @@ createTask(db, {
   recurMode: "completion",
 });
 
-const _cs3120hw = createTask(db, {
+const _cs3120hw = createTask(db, userId, {
   description: "CS 3120: Homework 6 — NP-completeness proofs",
   category: "School",
   priority: 3,
@@ -101,56 +106,56 @@ const _cs3120hw = createTask(db, {
   status: "wip",
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "CS 3120: Study for midterm 2",
   category: "School",
   priority: 2,
   due: daysFromNow(12),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "MATH 3354: Problem set 8 — ring homomorphisms",
   category: "School",
   priority: 2,
   due: daysFromNow(4),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "PSYC 2410: Read Chapter 12 — Social Cognition",
   category: "School",
   priority: 1,
   due: daysFromNow(6),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Prepare IMC onboarding documents",
   category: "Career",
   priority: 1,
   due: daysFromNow(90),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Set up Chicago apartment search alerts",
   category: "Career",
   priority: 2,
   due: daysFromNow(30),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Send thank-you note to Ramp manager",
   category: "Career",
   priority: 1,
   due: daysFromNow(2),
 });
 
-const lektraBuild = createTask(db, {
+const lektraBuild = createTask(db, userId, {
   description: "Fix lektra build on NixOS 24.11",
   category: "Open Source",
   priority: 2,
   status: "wip",
 });
 
-const lektraRelease = createTask(db, {
+const lektraRelease = createTask(db, userId, {
   description: "Tag lektra v2.0 release",
   category: "Open Source",
   priority: 1,
@@ -158,7 +163,7 @@ const lektraRelease = createTask(db, {
 });
 addDependency(db, lektraRelease.id, lektraBuild.id);
 
-createTask(db, {
+createTask(db, userId, {
   description: "Weekly grocery run",
   category: "Todo",
   priority: 0,
@@ -167,7 +172,7 @@ createTask(db, {
   recurMode: "scheduled",
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Clean apartment",
   category: "Todo",
   priority: 0,
@@ -176,7 +181,7 @@ createTask(db, {
   recurMode: "completion",
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Back up NixOS config to Forgejo",
   category: "Todo",
   priority: 1,
@@ -185,28 +190,28 @@ createTask(db, {
   recurMode: "scheduled",
 });
 
-const completedOld = createTask(db, {
+const completedOld = createTask(db, userId, {
   description: "Set up delta deploy pipeline",
   category: "Open Source",
   priority: 2,
 });
 updateTask(db, completedOld.id, { status: "done" });
 
-const completedOld2 = createTask(db, {
+const completedOld2 = createTask(db, userId, {
   description: "Write delta Drizzle schema",
   category: "Open Source",
   priority: 2,
 });
 updateTask(db, completedOld2.id, { status: "done" });
 
-const completedOld3 = createTask(db, {
+const completedOld3 = createTask(db, userId, {
   description: "Submit DRW expense report",
   category: "Career",
   priority: 1,
 });
 updateTask(db, completedOld3.id, { status: "done" });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Update barrettruth.com portfolio with delta",
   category: "Career",
   priority: 1,
@@ -263,7 +268,7 @@ createTask(db, {
   }),
 });
 
-createTask(db, {
+createTask(db, userId, {
   description: "Investigate vikunja as delta alternative",
   category: "Todo",
   priority: 0,

--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { CalendarView } from "@/components/calendar-view";
 import { validateSession } from "@/core/auth";
 import { getSettings } from "@/core/settings";
@@ -8,10 +9,12 @@ import { db } from "@/db";
 export default async function CalendarPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get("session")?.value;
-  const user = sessionId ? validateSession(db, sessionId) : null;
-  const settings = user ? getSettings(db, user.id) : null;
+  if (!sessionId) redirect("/login");
+  const user = validateSession(db, sessionId);
+  if (!user) redirect("/login");
+  const settings = getSettings(db, user.id);
 
-  const tasks = listTasks(db);
+  const tasks = listTasks(db, user.id);
   const categories = [
     ...new Set(tasks.map((t) => t.category).filter(Boolean)),
   ] as string[];
@@ -19,8 +22,8 @@ export default async function CalendarPage() {
     <CalendarView
       tasks={tasks}
       categories={categories}
-      weekStartDay={settings?.weekStartDay ?? 1}
-      defaultCategory={settings?.defaultCategory}
+      weekStartDay={settings.weekStartDay ?? 1}
+      defaultCategory={settings.defaultCategory}
     />
   );
 }

--- a/src/app/(dashboard)/kanban/page.tsx
+++ b/src/app/(dashboard)/kanban/page.tsx
@@ -1,8 +1,20 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { KanbanBoard } from "@/components/kanban-board";
+import { validateSession } from "@/core/auth";
 import { listTasks } from "@/core/task";
 import { db } from "@/db";
 
-export default function KanbanPage() {
-  const tasks = listTasks(db, { sortBy: "priority", sortOrder: "desc" });
+export default async function KanbanPage() {
+  const cookieStore = await cookies();
+  const sessionId = cookieStore.get("session")?.value;
+  if (!sessionId) redirect("/login");
+  const user = validateSession(db, sessionId);
+  if (!user) redirect("/login");
+
+  const tasks = listTasks(db, user.id, {
+    sortBy: "priority",
+    sortOrder: "desc",
+  });
   return <KanbanBoard tasks={tasks} />;
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -23,7 +24,7 @@ export default async function DashboardLayout({
   const user = validateSession(db, sessionId);
   if (!user) redirect("/login");
 
-  const allTasks = listTasks(db);
+  const allTasks = listTasks(db, user.id);
   const categories = [
     ...new Set(allTasks.map((t) => t.category).filter(Boolean)),
   ] as string[];
@@ -32,6 +33,7 @@ export default async function DashboardLayout({
     db
       .select()
       .from(categoryColors)
+      .where(eq(categoryColors.userId, user.id))
       .all()
       .map((c) => [c.category, c.color]),
   );

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -24,11 +24,12 @@ export default async function QueuePage({
   const params = await searchParams;
   const cookieStore = await cookies();
   const sessionId = cookieStore.get("session")?.value;
-  const user = sessionId ? validateSession(db, sessionId) : null;
-  const settings = user ? getSettings(db, user.id) : null;
+  if (!sessionId) redirect("/login");
+  const user = validateSession(db, sessionId);
+  if (!user) redirect("/login");
+  const settings = getSettings(db, user.id);
 
   if (
-    settings &&
     settings.defaultView !== "queue" &&
     settings.defaultView !== "list" &&
     !params.category &&
@@ -44,13 +45,13 @@ export default async function QueuePage({
     filters.status = params.status.split(",") as TaskStatus[];
   }
 
-  if (settings && !settings.showCompletedTasks && !params.status) {
+  if (!settings.showCompletedTasks && !params.status) {
     filters.status = ["pending", "wip", "blocked"];
   }
 
-  const allTasks = listTasks(db);
-  const tasks = listTasks(db, filters);
-  const ranked = rankTasks(db, tasks, settings?.urgencyWeights);
+  const allTasks = listTasks(db, user.id);
+  const tasks = listTasks(db, user.id, filters);
+  const ranked = rankTasks(db, tasks, settings.urgencyWeights);
   const categories = [
     ...new Set(allTasks.map((t) => t.category).filter(Boolean)),
   ] as string[];
@@ -59,7 +60,7 @@ export default async function QueuePage({
     <QueueView
       tasks={ranked}
       categories={categories}
-      defaultCategory={settings?.defaultCategory}
+      defaultCategory={settings.defaultCategory}
     />
   );
 }

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -14,7 +14,7 @@ export default async function SettingsPage() {
   if (!user) redirect("/login");
 
   const settings = getSettings(db, user.id);
-  const allTasks = listTasks(db);
+  const allTasks = listTasks(db, user.id);
   const categories = [
     ...new Set(allTasks.map((t) => t.category).filter(Boolean)),
   ] as string[];

--- a/src/app/actions/tasks.ts
+++ b/src/app/actions/tasks.ts
@@ -1,20 +1,41 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { addDependency, removeDependency } from "@/core/dag";
-import { completeTask, createTask, deleteTask, updateTask } from "@/core/task";
+import {
+  completeTask,
+  createTask,
+  deleteTask,
+  getTask,
+  updateTask,
+} from "@/core/task";
 import type { CreateTaskInput, UpdateTaskInput } from "@/core/types";
 import { db } from "@/db";
 import { categoryColors } from "@/db/schema";
+import { getAuthUser } from "@/lib/auth-middleware";
 
 type ActionResult<T> = { data: T } | { error: string };
+
+async function requireUser() {
+  const user = await getAuthUser();
+  if (!user) throw new Error("Not authenticated");
+  return user;
+}
+
+async function requireOwnedTask(taskId: number) {
+  const user = await requireUser();
+  const task = getTask(db, taskId);
+  if (!task || task.userId !== user.id) throw new Error("Task not found");
+  return { user, task };
+}
 
 export async function createTaskAction(
   input: CreateTaskInput,
 ): Promise<ActionResult<ReturnType<typeof createTask>>> {
   try {
-    const task = createTask(db, input);
+    const user = await requireUser();
+    const task = createTask(db, user.id, input);
     revalidatePath("/");
     return { data: task };
   } catch (e) {
@@ -27,6 +48,8 @@ export async function updateTaskAction(
   input: UpdateTaskInput,
 ): Promise<ActionResult<ReturnType<typeof updateTask>>> {
   try {
+    const { user } = await requireOwnedTask(id);
+    void user;
     const task = updateTask(db, id, input);
     revalidatePath("/");
     return { data: task };
@@ -39,7 +62,8 @@ export async function completeTaskAction(
   id: number,
 ): Promise<ActionResult<ReturnType<typeof completeTask>>> {
   try {
-    const task = completeTask(db, id);
+    const { user } = await requireOwnedTask(id);
+    const task = completeTask(db, user.id, id);
     revalidatePath("/");
     return { data: task };
   } catch (e) {
@@ -53,6 +77,7 @@ export async function deleteTaskAction(
   id: number,
 ): Promise<ActionResult<ReturnType<typeof deleteTask>>> {
   try {
+    await requireOwnedTask(id);
     const task = deleteTask(db, id);
     revalidatePath("/");
     return { data: task };
@@ -66,6 +91,8 @@ export async function addDependencyAction(
   dependsOnId: number,
 ): Promise<ActionResult<null>> {
   try {
+    await requireOwnedTask(taskId);
+    await requireOwnedTask(dependsOnId);
     addDependency(db, taskId, dependsOnId);
     revalidatePath("/");
     return { data: null };
@@ -81,10 +108,11 @@ export async function setCategoryColorAction(
   color: string,
 ): Promise<ActionResult<null>> {
   try {
+    const user = await requireUser();
     db.insert(categoryColors)
-      .values({ category, color })
+      .values({ userId: user.id, category, color })
       .onConflictDoUpdate({
-        target: categoryColors.category,
+        target: [categoryColors.userId, categoryColors.category],
         set: { color },
       })
       .run();
@@ -101,8 +129,14 @@ export async function removeCategoryColorAction(
   category: string,
 ): Promise<ActionResult<null>> {
   try {
+    const user = await requireUser();
     db.delete(categoryColors)
-      .where(eq(categoryColors.category, category))
+      .where(
+        and(
+          eq(categoryColors.userId, user.id),
+          eq(categoryColors.category, category),
+        ),
+      )
       .run();
     revalidatePath("/");
     return { data: null };
@@ -118,6 +152,7 @@ export async function removeDependencyAction(
   dependsOnId: number,
 ): Promise<ActionResult<null>> {
   try {
+    await requireOwnedTask(taskId);
     removeDependency(db, taskId, dependsOnId);
     revalidatePath("/");
     return { data: null };

--- a/src/app/api/automations/[id]/route.ts
+++ b/src/app/api/automations/[id]/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { automations } from "@/db/schema";
@@ -6,19 +6,20 @@ import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
 
 type Params = { params: Promise<{ id: string }> };
 
+function getOwnedAutomation(userId: number, id: number) {
+  return db
+    .select()
+    .from(automations)
+    .where(and(eq(automations.id, id), eq(automations.userId, userId)))
+    .get();
+}
+
 export async function PATCH(request: Request, { params }: Params) {
   const user = await getAuthUserFromRequest(request);
   if (!user) return unauthorized();
 
   const { id } = await params;
-  const body = await request.json();
-
-  const existing = db
-    .select()
-    .from(automations)
-    .where(eq(automations.id, Number(id)))
-    .get();
-
+  const existing = getOwnedAutomation(user.id, Number(id));
   if (!existing) {
     return NextResponse.json(
       { error: "Automation not found" },
@@ -26,6 +27,7 @@ export async function PATCH(request: Request, { params }: Params) {
     );
   }
 
+  const body = await request.json();
   if (body.config && typeof body.config !== "string") {
     body.config = JSON.stringify(body.config);
   }
@@ -45,6 +47,14 @@ export async function DELETE(request: Request, { params }: Params) {
   if (!user) return unauthorized();
 
   const { id } = await params;
+  const existing = getOwnedAutomation(user.id, Number(id));
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Automation not found" },
+      { status: 404 },
+    );
+  }
+
   db.delete(automations)
     .where(eq(automations.id, Number(id)))
     .run();

--- a/src/app/api/automations/[id]/run/route.ts
+++ b/src/app/api/automations/[id]/run/route.ts
@@ -1,6 +1,8 @@
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { runAutomation } from "@/core/automation";
 import { db } from "@/db";
+import { automations } from "@/db/schema";
 import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
 
 type Params = { params: Promise<{ id: string }> };
@@ -10,6 +12,19 @@ export async function POST(request: Request, { params }: Params) {
   if (!user) return unauthorized();
 
   const { id } = await params;
+  const existing = db
+    .select()
+    .from(automations)
+    .where(and(eq(automations.id, Number(id)), eq(automations.userId, user.id)))
+    .get();
+
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Automation not found" },
+      { status: 404 },
+    );
+  }
+
   try {
     await runAutomation(db, Number(id));
     return NextResponse.json({ ok: true });

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { automations } from "@/db/schema";
@@ -7,7 +8,9 @@ export async function GET(request: Request) {
   const user = await getAuthUserFromRequest(request);
   if (!user) return unauthorized();
 
-  return NextResponse.json(db.select().from(automations).all());
+  return NextResponse.json(
+    db.select().from(automations).where(eq(automations.userId, user.id)).all(),
+  );
 }
 
 export async function POST(request: Request) {
@@ -26,6 +29,7 @@ export async function POST(request: Request) {
   const automation = db
     .insert(automations)
     .values({
+      userId: user.id,
       name: body.name,
       cron: body.cron,
       type: body.type,

--- a/src/app/api/tasks/[id]/deps/[depId]/route.ts
+++ b/src/app/api/tasks/[id]/deps/[depId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { removeDependency } from "@/core/dag";
+import { getTask } from "@/core/task";
 import { db } from "@/db";
 import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
 
@@ -10,6 +11,11 @@ export async function DELETE(request: Request, { params }: Params) {
   if (!user) return unauthorized();
 
   const { id, depId } = await params;
+  const task = getTask(db, Number(id));
+  if (!task || task.userId !== user.id) {
+    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  }
+
   removeDependency(db, Number(id), Number(depId));
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/tasks/[id]/deps/route.ts
+++ b/src/app/api/tasks/[id]/deps/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { addDependency, getDependencies } from "@/core/dag";
+import { getTask } from "@/core/task";
 import { db } from "@/db";
 import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
 
@@ -10,6 +11,11 @@ export async function GET(request: Request, { params }: Params) {
   if (!user) return unauthorized();
 
   const { id } = await params;
+  const task = getTask(db, Number(id));
+  if (!task || task.userId !== user.id) {
+    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  }
+
   return NextResponse.json(getDependencies(db, Number(id)));
 }
 
@@ -24,6 +30,19 @@ export async function POST(request: Request, { params }: Params) {
     return NextResponse.json(
       { error: "depends_on_id is required" },
       { status: 400 },
+    );
+  }
+
+  const task = getTask(db, Number(id));
+  if (!task || task.userId !== user.id) {
+    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  }
+
+  const dep = getTask(db, body.depends_on_id);
+  if (!dep || dep.userId !== user.id) {
+    return NextResponse.json(
+      { error: "Dependency task not found" },
+      { status: 404 },
     );
   }
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -6,12 +6,20 @@ import { validateUpdateTask } from "@/lib/validation";
 
 type Params = { params: Promise<{ id: string }> };
 
+function requireOwnership(
+  task: { userId: number } | undefined,
+  userId: number,
+) {
+  if (!task || task.userId !== userId) return null;
+  return task;
+}
+
 export async function GET(request: Request, { params }: Params) {
   const user = await getAuthUserFromRequest(request);
   if (!user) return unauthorized();
 
   const { id } = await params;
-  const task = getTask(db, Number(id));
+  const task = requireOwnership(getTask(db, Number(id)), user.id);
   if (!task) {
     return NextResponse.json({ error: "Task not found" }, { status: 404 });
   }
@@ -24,8 +32,12 @@ export async function PATCH(request: Request, { params }: Params) {
   if (!user) return unauthorized();
 
   const { id } = await params;
-  const body = await request.json();
+  const existing = requireOwnership(getTask(db, Number(id)), user.id);
+  if (!existing) {
+    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  }
 
+  const body = await request.json();
   const result = validateUpdateTask(body);
   if (!result.success || !result.data) {
     return NextResponse.json(
@@ -38,7 +50,7 @@ export async function PATCH(request: Request, { params }: Params) {
 
   try {
     if (validated.status === "done") {
-      const task = completeTask(db, Number(id));
+      const task = completeTask(db, user.id, Number(id));
       return NextResponse.json(task);
     }
 
@@ -57,6 +69,11 @@ export async function DELETE(request: Request, { params }: Params) {
   if (!user) return unauthorized();
 
   const { id } = await params;
+  const existing = requireOwnership(getTask(db, Number(id)), user.id);
+  if (!existing) {
+    return NextResponse.json({ error: "Task not found" }, { status: 404 });
+  }
+
   try {
     const task = deleteTask(db, Number(id));
     return NextResponse.json(task);

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
   const sortOrder = searchParams.get("sort_order");
   if (sortOrder) filters.sortOrder = sortOrder as TaskFilters["sortOrder"];
 
-  return NextResponse.json(listTasks(db, filters));
+  return NextResponse.json(listTasks(db, user.id, filters));
 }
 
 export async function POST(request: Request) {
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const task = createTask(db, result.data);
+    const task = createTask(db, user.id, result.data);
     return NextResponse.json(task, { status: 201 });
   } catch (e) {
     const message = e instanceof Error ? e.message : "Failed to create task";

--- a/src/core/automation.ts
+++ b/src/core/automation.ts
@@ -3,7 +3,11 @@ import { type ScheduledTask, schedule, validate } from "node-cron";
 import { automations } from "@/db/schema";
 import type { Db } from "./types";
 
-export type RecipeHandler = (db: Db, config: unknown) => Promise<void>;
+export type RecipeHandler = (
+  db: Db,
+  userId: number,
+  config: unknown,
+) => Promise<void>;
 
 const recipes = new Map<string, RecipeHandler>();
 const jobs = new Map<number, ScheduledTask>();
@@ -38,7 +42,7 @@ export async function runAutomation(
   }
 
   const config: unknown = JSON.parse(automation.config);
-  await handler(db, config);
+  await handler(db, automation.userId, config);
 
   db.update(automations)
     .set({ lastRunAt: new Date().toISOString() })

--- a/src/core/recipes/github-issues.ts
+++ b/src/core/recipes/github-issues.ts
@@ -94,6 +94,7 @@ function taskExistsForIssue(
 
 export async function githubIssuesHandler(
   db: Db,
+  userId: number,
   config: unknown,
 ): Promise<void> {
   if (!isValidConfig(config)) {
@@ -121,7 +122,7 @@ export async function githubIssuesHandler(
 
       if (taskExistsForIssue(db, repo, issue.number)) continue;
 
-      createTask(db, {
+      createTask(db, userId, {
         description: formatDescription(repo, issue.title, issue.number),
         category,
       });

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -14,11 +14,16 @@ function timestamp(): string {
   return new Date().toISOString();
 }
 
-export function createTask(db: Db, input: CreateTaskInput): Task {
+export function createTask(
+  db: Db,
+  userId: number,
+  input: CreateTaskInput,
+): Task {
   const ts = timestamp();
   return db
     .insert(tasks)
     .values({
+      userId,
       description: input.description,
       status: input.status ?? "pending",
       category: input.category ?? "Todo",
@@ -52,8 +57,12 @@ function getSortColumn(sortBy: string | undefined) {
   }
 }
 
-export function listTasks(db: Db, filters?: TaskFilters): Task[] {
-  const conditions = [];
+export function listTasks(
+  db: Db,
+  userId: number,
+  filters?: TaskFilters,
+): Task[] {
+  const conditions = [eq(tasks.userId, userId)];
 
   if (filters?.status) {
     if (Array.isArray(filters.status)) {
@@ -79,7 +88,7 @@ export function listTasks(db: Db, filters?: TaskFilters): Task[] {
     conditions.push(gte(tasks.priority, filters.minPriority));
   }
 
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const where = and(...conditions);
   const sortColumn = getSortColumn(filters?.sortBy);
   const sortFn = filters?.sortOrder === "asc" ? asc : desc;
 
@@ -112,11 +121,11 @@ export function updateTask(db: Db, id: number, input: UpdateTaskInput): Task {
     .get();
 }
 
-export function completeTask(db: Db, id: number): Task {
+export function completeTask(db: Db, userId: number, id: number): Task {
   const task = updateTask(db, id, { status: "done" });
 
   const nextData = getNextTaskData(task);
-  if (nextData) createTask(db, nextData);
+  if (nextData) createTask(db, userId, nextData);
 
   updateBlockedStatus(db, id);
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,6 +15,9 @@ export const users = sqliteTable("users", {
 
 export const tasks = sqliteTable("tasks", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
   description: text("description").notNull(),
   status: text("status", {
     enum: ["pending", "done", "wip", "blocked", "cancelled"],
@@ -55,10 +58,17 @@ export const sessions = sqliteTable("sessions", {
   createdAt: text("created_at").notNull(),
 });
 
-export const categoryColors = sqliteTable("category_colors", {
-  category: text("category").primaryKey(),
-  color: text("color").notNull(),
-});
+export const categoryColors = sqliteTable(
+  "category_colors",
+  {
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    category: text("category").notNull(),
+    color: text("color").notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.category] })],
+);
 
 export const userSettings = sqliteTable("user_settings", {
   userId: integer("user_id")
@@ -69,6 +79,9 @@ export const userSettings = sqliteTable("user_settings", {
 
 export const automations = sqliteTable("automations", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
   cron: text("cron").notNull(),
   type: text("type").notNull(),

--- a/tests/api/deps.test.ts
+++ b/tests/api/deps.test.ts
@@ -7,18 +7,20 @@ import {
 } from "@/core/dag";
 import { completeTask, createTask, deleteTask, getTask } from "@/core/task";
 import type { Db } from "@/core/types";
-import { createTestDb } from "../helpers";
+import { createTestDb, createTestUser } from "../helpers";
 
 let db: Db;
+let userId: number;
 
 beforeEach(() => {
   db = createTestDb();
+  userId = createTestUser(db).id;
 });
 
 describe("dependency management end-to-end", () => {
   it("adding dependency blocks the dependent task", () => {
-    const upstream = createTask(db, { description: "Build API" });
-    const downstream = createTask(db, { description: "Build UI" });
+    const upstream = createTask(db, userId, { description: "Build API" });
+    const downstream = createTask(db, userId, { description: "Build UI" });
 
     addDependency(db, downstream.id, upstream.id);
 
@@ -31,19 +33,19 @@ describe("dependency management end-to-end", () => {
   });
 
   it("completing dependency unblocks the dependent task", () => {
-    const upstream = createTask(db, { description: "Setup DB" });
-    const downstream = createTask(db, { description: "Write queries" });
+    const upstream = createTask(db, userId, { description: "Setup DB" });
+    const downstream = createTask(db, userId, { description: "Write queries" });
 
     addDependency(db, downstream.id, upstream.id);
     expect(getTask(db, downstream.id)?.status).toBe("blocked");
 
-    completeTask(db, upstream.id);
+    completeTask(db, userId, upstream.id);
     expect(getTask(db, downstream.id)?.status).toBe("pending");
   });
 
   it("removing the last dependency unblocks the task", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
 
     addDependency(db, b.id, a.id);
     expect(getTask(db, b.id)?.status).toBe("blocked");
@@ -54,9 +56,9 @@ describe("dependency management end-to-end", () => {
   });
 
   it("removing one of multiple dependencies keeps task blocked", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
 
     addDependency(db, c.id, a.id);
     addDependency(db, c.id, b.id);
@@ -67,8 +69,8 @@ describe("dependency management end-to-end", () => {
   });
 
   it("cancelling dependency unblocks the dependent task", () => {
-    const upstream = createTask(db, { description: "Cancelled dep" });
-    const downstream = createTask(db, { description: "Waiting" });
+    const upstream = createTask(db, userId, { description: "Cancelled dep" });
+    const downstream = createTask(db, userId, { description: "Waiting" });
 
     addDependency(db, downstream.id, upstream.id);
     expect(getTask(db, downstream.id)?.status).toBe("blocked");
@@ -80,24 +82,24 @@ describe("dependency management end-to-end", () => {
 
 describe("cycle detection", () => {
   it("prevents self-dependency", () => {
-    const a = createTask(db, { description: "Self" });
+    const a = createTask(db, userId, { description: "Self" });
     expect(() => addDependency(db, a.id, a.id)).toThrow(
       "cannot depend on itself",
     );
   });
 
   it("prevents direct cycle A -> B -> A", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
 
     addDependency(db, a.id, b.id);
     expect(() => addDependency(db, b.id, a.id)).toThrow("cycle");
   });
 
   it("prevents indirect cycle A -> B -> C -> A", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
 
     addDependency(db, a.id, b.id);
     addDependency(db, b.id, c.id);
@@ -105,10 +107,10 @@ describe("cycle detection", () => {
   });
 
   it("prevents cycle across longer chains A -> B -> C -> D -> A", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
-    const d = createTask(db, { description: "D" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
+    const d = createTask(db, userId, { description: "D" });
 
     addDependency(db, a.id, b.id);
     addDependency(db, b.id, c.id);
@@ -118,10 +120,10 @@ describe("cycle detection", () => {
   });
 
   it("allows valid non-cyclic diamond dependency", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
-    const d = createTask(db, { description: "D" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
+    const d = createTask(db, userId, { description: "D" });
 
     addDependency(db, a.id, b.id);
     addDependency(db, a.id, c.id);
@@ -132,36 +134,36 @@ describe("cycle detection", () => {
 
 describe("multi-dependency unblocking", () => {
   it("unblocks only when all dependencies are resolved", () => {
-    const dep1 = createTask(db, { description: "Dep 1" });
-    const dep2 = createTask(db, { description: "Dep 2" });
-    const dep3 = createTask(db, { description: "Dep 3" });
-    const task = createTask(db, { description: "Blocked task" });
+    const dep1 = createTask(db, userId, { description: "Dep 1" });
+    const dep2 = createTask(db, userId, { description: "Dep 2" });
+    const dep3 = createTask(db, userId, { description: "Dep 3" });
+    const task = createTask(db, userId, { description: "Blocked task" });
 
     addDependency(db, task.id, dep1.id);
     addDependency(db, task.id, dep2.id);
     addDependency(db, task.id, dep3.id);
     expect(getTask(db, task.id)?.status).toBe("blocked");
 
-    completeTask(db, dep1.id);
+    completeTask(db, userId, dep1.id);
     expect(getTask(db, task.id)?.status).toBe("blocked");
 
-    completeTask(db, dep2.id);
+    completeTask(db, userId, dep2.id);
     expect(getTask(db, task.id)?.status).toBe("blocked");
 
-    completeTask(db, dep3.id);
+    completeTask(db, userId, dep3.id);
     expect(getTask(db, task.id)?.status).toBe("pending");
   });
 
   it("treats mix of done and cancelled as all resolved", () => {
-    const dep1 = createTask(db, { description: "Will complete" });
-    const dep2 = createTask(db, { description: "Will cancel" });
-    const task = createTask(db, { description: "Waiting" });
+    const dep1 = createTask(db, userId, { description: "Will complete" });
+    const dep2 = createTask(db, userId, { description: "Will cancel" });
+    const task = createTask(db, userId, { description: "Waiting" });
 
     addDependency(db, task.id, dep1.id);
     addDependency(db, task.id, dep2.id);
     expect(getTask(db, task.id)?.status).toBe("blocked");
 
-    completeTask(db, dep1.id);
+    completeTask(db, userId, dep1.id);
     expect(getTask(db, task.id)?.status).toBe("blocked");
 
     deleteTask(db, dep2.id);
@@ -169,10 +171,10 @@ describe("multi-dependency unblocking", () => {
   });
 
   it("getDependents returns all tasks that depend on a given task", () => {
-    const upstream = createTask(db, { description: "Shared dep" });
-    const d1 = createTask(db, { description: "Dependent 1" });
-    const d2 = createTask(db, { description: "Dependent 2" });
-    const d3 = createTask(db, { description: "Dependent 3" });
+    const upstream = createTask(db, userId, { description: "Shared dep" });
+    const d1 = createTask(db, userId, { description: "Dependent 1" });
+    const d2 = createTask(db, userId, { description: "Dependent 2" });
+    const d3 = createTask(db, userId, { description: "Dependent 3" });
 
     addDependency(db, d1.id, upstream.id);
     addDependency(db, d2.id, upstream.id);
@@ -186,9 +188,9 @@ describe("multi-dependency unblocking", () => {
   });
 
   it("completing shared dependency unblocks multiple dependents", () => {
-    const shared = createTask(db, { description: "Shared" });
-    const t1 = createTask(db, { description: "T1" });
-    const t2 = createTask(db, { description: "T2" });
+    const shared = createTask(db, userId, { description: "Shared" });
+    const t1 = createTask(db, userId, { description: "T1" });
+    const t2 = createTask(db, userId, { description: "T2" });
 
     addDependency(db, t1.id, shared.id);
     addDependency(db, t2.id, shared.id);
@@ -196,7 +198,7 @@ describe("multi-dependency unblocking", () => {
     expect(getTask(db, t1.id)?.status).toBe("blocked");
     expect(getTask(db, t2.id)?.status).toBe("blocked");
 
-    completeTask(db, shared.id);
+    completeTask(db, userId, shared.id);
 
     expect(getTask(db, t1.id)?.status).toBe("pending");
     expect(getTask(db, t2.id)?.status).toBe("pending");

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -9,17 +9,19 @@ import {
   updateTask,
 } from "@/core/task";
 import type { Db } from "@/core/types";
-import { createTestDb } from "../helpers";
+import { createTestDb, createTestUser } from "../helpers";
 
 let db: Db;
+let userId: number;
 
 beforeEach(() => {
   db = createTestDb();
+  userId = createTestUser(db).id;
 });
 
 describe("task lifecycle", () => {
   it("create, list, update, complete, delete end-to-end", () => {
-    const task = createTask(db, {
+    const task = createTask(db, userId, {
       description: "Write tests",
       category: "Dev",
       priority: 2,
@@ -29,7 +31,7 @@ describe("task lifecycle", () => {
     expect(task.id).toBe(1);
     expect(task.status).toBe("pending");
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(1);
     expect(all[0].id).toBe(task.id);
 
@@ -41,26 +43,26 @@ describe("task lifecycle", () => {
     expect(updated.priority).toBe(3);
     expect(updated.updatedAt).not.toBe(task.updatedAt);
 
-    const completed = completeTask(db, task.id);
+    const completed = completeTask(db, userId, task.id);
     expect(completed.status).toBe("done");
     expect(completed.completedAt).toBeTruthy();
 
-    const afterComplete = listTasks(db);
+    const afterComplete = listTasks(db, userId);
     expect(afterComplete).toHaveLength(1);
     expect(afterComplete[0].status).toBe("done");
   });
 
   it("creates multiple tasks and lists them all", () => {
-    createTask(db, { description: "Task 1" });
-    createTask(db, { description: "Task 2" });
-    createTask(db, { description: "Task 3" });
+    createTask(db, userId, { description: "Task 1" });
+    createTask(db, userId, { description: "Task 2" });
+    createTask(db, userId, { description: "Task 3" });
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(3);
   });
 
   it("soft deletes via deleteTask", () => {
-    const task = createTask(db, { description: "Doomed" });
+    const task = createTask(db, userId, { description: "Doomed" });
     const deleted = deleteTask(db, task.id);
 
     expect(deleted.status).toBe("cancelled");
@@ -73,7 +75,7 @@ describe("task lifecycle", () => {
 
 describe("status transitions", () => {
   it("pending -> wip -> done", () => {
-    const task = createTask(db, { description: "Flow test" });
+    const task = createTask(db, userId, { description: "Flow test" });
     expect(task.status).toBe("pending");
 
     const wip = updateTask(db, task.id, { status: "wip" });
@@ -86,19 +88,18 @@ describe("status transitions", () => {
   });
 
   it("pending -> blocked via dependency -> pending via auto-unblock", () => {
-    const blocker = createTask(db, { description: "Blocker" });
-    const blocked = createTask(db, { description: "Blocked" });
-    addDependency(db, blocked.id, blocker.id);
+    const blocker = createTask(db, userId, { description: "Blocker" });
+    const blocked = createTask(db, userId, { description: "Blocked" });
 
+    addDependency(db, blocked.id, blocker.id);
     expect(getTask(db, blocked.id)?.status).toBe("blocked");
 
-    completeTask(db, blocker.id);
-
+    completeTask(db, userId, blocker.id);
     expect(getTask(db, blocked.id)?.status).toBe("pending");
   });
 
   it("done -> pending clears completedAt", () => {
-    const task = createTask(db, { description: "Reopenable" });
+    const task = createTask(db, userId, { description: "Reopenable" });
     const done = updateTask(db, task.id, { status: "done" });
     expect(done.completedAt).toBeTruthy();
 
@@ -108,7 +109,7 @@ describe("status transitions", () => {
   });
 
   it("cancelled -> wip clears completedAt", () => {
-    const task = createTask(db, { description: "Revived" });
+    const task = createTask(db, userId, { description: "Revived" });
     const cancelled = deleteTask(db, task.id);
     expect(cancelled.completedAt).toBeTruthy();
 
@@ -120,28 +121,28 @@ describe("status transitions", () => {
 
 describe("listing filters", () => {
   beforeEach(() => {
-    createTask(db, {
+    createTask(db, userId, {
       description: "Work task",
       status: "pending",
       category: "Work",
       priority: 3,
       due: "2026-04-01T00:00:00.000Z",
     });
-    createTask(db, {
+    createTask(db, userId, {
       description: "Personal task",
       status: "done",
       category: "Personal",
       priority: 1,
       due: "2026-03-15T00:00:00.000Z",
     });
-    createTask(db, {
+    createTask(db, userId, {
       description: "Urgent work",
       status: "wip",
       category: "Work",
       priority: 5,
       due: "2026-03-20T00:00:00.000Z",
     });
-    createTask(db, {
+    createTask(db, userId, {
       description: "Low prio",
       status: "pending",
       category: "Personal",
@@ -150,13 +151,13 @@ describe("listing filters", () => {
   });
 
   it("filters by single status", () => {
-    const pending = listTasks(db, { status: "pending" });
+    const pending = listTasks(db, userId, { status: "pending" });
     expect(pending).toHaveLength(2);
     expect(pending.every((t) => t.status === "pending")).toBe(true);
   });
 
   it("filters by multiple statuses", () => {
-    const active = listTasks(db, { status: ["pending", "wip"] });
+    const active = listTasks(db, userId, { status: ["pending", "wip"] });
     expect(active).toHaveLength(3);
     expect(
       active.every((t) => t.status === "pending" || t.status === "wip"),
@@ -164,13 +165,13 @@ describe("listing filters", () => {
   });
 
   it("filters by category", () => {
-    const work = listTasks(db, { category: "Work" });
+    const work = listTasks(db, userId, { category: "Work" });
     expect(work).toHaveLength(2);
     expect(work.every((t) => t.category === "Work")).toBe(true);
   });
 
   it("filters by due date range", () => {
-    const range = listTasks(db, {
+    const range = listTasks(db, userId, {
       dueAfter: "2026-03-18T00:00:00.000Z",
       dueBefore: "2026-03-25T00:00:00.000Z",
     });
@@ -179,25 +180,31 @@ describe("listing filters", () => {
   });
 
   it("filters by minimum priority", () => {
-    const highPrio = listTasks(db, { minPriority: 3 });
+    const highPrio = listTasks(db, userId, { minPriority: 3 });
     expect(highPrio).toHaveLength(2);
     expect(highPrio.every((t) => (t.priority ?? 0) >= 3)).toBe(true);
   });
 
   it("combines status and category filters", () => {
-    const result = listTasks(db, { status: "pending", category: "Personal" });
+    const result = listTasks(db, userId, {
+      status: "pending",
+      category: "Personal",
+    });
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe("Low prio");
   });
 
   it("sorts by priority descending", () => {
-    const sorted = listTasks(db, { sortBy: "priority", sortOrder: "desc" });
+    const sorted = listTasks(db, userId, {
+      sortBy: "priority",
+      sortOrder: "desc",
+    });
     expect(sorted[0].priority).toBe(5);
     expect(sorted[sorted.length - 1].priority).toBe(0);
   });
 
   it("sorts by due ascending", () => {
-    const sorted = listTasks(db, { sortBy: "due", sortOrder: "asc" });
+    const sorted = listTasks(db, userId, { sortBy: "due", sortOrder: "asc" });
     const withDue = sorted.filter((t) => t.due !== null);
     for (let i = 1; i < withDue.length; i++) {
       expect((withDue[i].due ?? "") >= (withDue[i - 1].due ?? "")).toBe(true);
@@ -205,14 +212,14 @@ describe("listing filters", () => {
   });
 
   it("returns empty array when no tasks match", () => {
-    const result = listTasks(db, { category: "NonexistentCategory" });
+    const result = listTasks(db, userId, { category: "NonexistentCategory" });
     expect(result).toHaveLength(0);
   });
 });
 
 describe("recurring task completion", () => {
   it("spawns a new pending task with next due date", () => {
-    createTask(db, {
+    createTask(db, userId, {
       description: "Weekly standup",
       due: "2026-03-22T09:00:00.000Z",
       recurrence: "FREQ=WEEKLY",
@@ -221,9 +228,9 @@ describe("recurring task completion", () => {
       priority: 2,
     });
 
-    completeTask(db, 1);
+    completeTask(db, userId, 1);
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(2);
 
     const original = all.find((t) => t.status === "done");
@@ -242,25 +249,25 @@ describe("recurring task completion", () => {
   });
 
   it("does not spawn when task has no recurrence", () => {
-    createTask(db, { description: "One-off task" });
-    completeTask(db, 1);
+    createTask(db, userId, { description: "One-off task" });
+    completeTask(db, userId, 1);
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(1);
     expect(all[0].status).toBe("done");
   });
 
   it("handles completion-based recurrence", () => {
-    createTask(db, {
+    createTask(db, userId, {
       description: "Water plants",
       due: "2026-03-20T08:00:00.000Z",
       recurrence: "FREQ=WEEKLY",
       recurMode: "completion",
     });
 
-    completeTask(db, 1);
+    completeTask(db, userId, 1);
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(2);
 
     const spawned = all.find((t) => t.status === "pending");
@@ -270,16 +277,16 @@ describe("recurring task completion", () => {
   });
 
   it("spawns daily recurring task", () => {
-    createTask(db, {
+    createTask(db, userId, {
       description: "Daily review",
       due: "2026-03-22T18:00:00.000Z",
       recurrence: "FREQ=DAILY",
       recurMode: "scheduled",
     });
 
-    completeTask(db, 1);
+    completeTask(db, userId, 1);
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(2);
 
     const spawned = all.find((t) => t.status === "pending");

--- a/tests/core/automation.test.ts
+++ b/tests/core/automation.test.ts
@@ -7,9 +7,10 @@ import {
 } from "@/core/automation";
 import type { Db } from "@/core/types";
 import { automations } from "@/db/schema";
-import { createTestDb } from "../helpers";
+import { createTestDb, createTestUser } from "../helpers";
 
 let db: Db;
+let userId: number;
 
 function insertAutomation(
   db: Db,
@@ -19,6 +20,7 @@ function insertAutomation(
   return db
     .insert(automations)
     .values({
+      userId,
       name: "Test Automation",
       cron: "0 9 * * *",
       type: "test_recipe",
@@ -34,6 +36,7 @@ function insertAutomation(
 
 beforeEach(() => {
   db = createTestDb();
+  userId = createTestUser(db).id;
 });
 
 describe("registerRecipe", () => {
@@ -72,7 +75,7 @@ describe("runAutomation", () => {
     await runAutomation(db, automation.id);
 
     expect(handler).toHaveBeenCalledOnce();
-    expect(handler).toHaveBeenCalledWith(db, { key: "value" });
+    expect(handler).toHaveBeenCalledWith(db, userId, { key: "value" });
 
     const updated = db
       .select()
@@ -135,7 +138,7 @@ describe("githubIssuesHandler", () => {
     const { githubIssuesHandler } = await import(
       "@/core/recipes/github-issues"
     );
-    await githubIssuesHandler(db, config);
+    await githubIssuesHandler(db, userId, config);
 
     const { tasks } = await import("@/db/schema");
     const allTasks = db.select().from(tasks).all();
@@ -149,7 +152,7 @@ describe("githubIssuesHandler", () => {
 
   it("skips issues that already have a corresponding task", async () => {
     const { createTask } = await import("@/core/task");
-    createTask(db, {
+    createTask(db, userId, {
       description: "[owner/repo] Existing issue (#5)",
     });
 
@@ -181,7 +184,7 @@ describe("githubIssuesHandler", () => {
     const { githubIssuesHandler } = await import(
       "@/core/recipes/github-issues"
     );
-    await githubIssuesHandler(db, {
+    await githubIssuesHandler(db, userId, {
       repos: ["owner/repo"],
       token: "ghp_test",
     });
@@ -197,9 +200,9 @@ describe("githubIssuesHandler", () => {
     const { githubIssuesHandler } = await import(
       "@/core/recipes/github-issues"
     );
-    await expect(githubIssuesHandler(db, { bad: true })).rejects.toThrow(
-      "Invalid github_issues config",
-    );
+    await expect(
+      githubIssuesHandler(db, userId, { bad: true }),
+    ).rejects.toThrow("Invalid github_issues config");
   });
 
   it("creates tasks without label filter", async () => {
@@ -231,7 +234,7 @@ describe("githubIssuesHandler", () => {
     const { githubIssuesHandler } = await import(
       "@/core/recipes/github-issues"
     );
-    await githubIssuesHandler(db, {
+    await githubIssuesHandler(db, userId, {
       repos: ["owner/repo"],
       token: "ghp_test",
     });

--- a/tests/core/dag.test.ts
+++ b/tests/core/dag.test.ts
@@ -9,18 +9,20 @@ import {
 } from "@/core/dag";
 import { createTask, getTask, updateTask } from "@/core/task";
 import type { Db } from "@/core/types";
-import { createTestDb } from "../helpers";
+import { createTestDb, createTestUser } from "../helpers";
 
 let db: Db;
+let userId: number;
 
 beforeEach(() => {
   db = createTestDb();
+  userId = createTestUser(db).id;
 });
 
 describe("addDependency", () => {
   it("adds a dependency between tasks", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
 
     const deps = getDependencies(db, a.id);
@@ -29,8 +31,8 @@ describe("addDependency", () => {
   });
 
   it("blocks the dependent task", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
 
     const task = getTask(db, a.id);
@@ -38,24 +40,24 @@ describe("addDependency", () => {
   });
 
   it("prevents self-dependency", () => {
-    const a = createTask(db, { description: "A" });
+    const a = createTask(db, userId, { description: "A" });
     expect(() => addDependency(db, a.id, a.id)).toThrow(
       "cannot depend on itself",
     );
   });
 
   it("detects direct cycle", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
 
     expect(() => addDependency(db, b.id, a.id)).toThrow("cycle");
   });
 
   it("detects indirect cycle", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
     addDependency(db, a.id, b.id);
     addDependency(db, b.id, c.id);
 
@@ -63,8 +65,8 @@ describe("addDependency", () => {
   });
 
   it("allows adding a dependency on a done task without blocking", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     updateTask(db, b.id, { status: "done" });
 
     addDependency(db, a.id, b.id);
@@ -74,8 +76,8 @@ describe("addDependency", () => {
   });
 
   it("does not block a non-pending task when adding a dependency", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     updateTask(db, a.id, { status: "wip" });
     addDependency(db, a.id, b.id);
 
@@ -86,8 +88,8 @@ describe("addDependency", () => {
 
 describe("removeDependency", () => {
   it("removes a dependency", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
     removeDependency(db, a.id, b.id);
 
@@ -95,8 +97,8 @@ describe("removeDependency", () => {
   });
 
   it("unblocks task when last dependency removed", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
 
     expect(getTask(db, a.id)?.status).toBe("blocked");
@@ -106,9 +108,9 @@ describe("removeDependency", () => {
   });
 
   it("keeps task blocked when other dependencies remain", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
     addDependency(db, a.id, b.id);
     addDependency(db, a.id, c.id);
 
@@ -119,9 +121,9 @@ describe("removeDependency", () => {
 
 describe("getDependencies", () => {
   it("returns all dependencies of a task", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
     addDependency(db, a.id, b.id);
     addDependency(db, a.id, c.id);
 
@@ -131,16 +133,16 @@ describe("getDependencies", () => {
   });
 
   it("returns empty array for task with no dependencies", () => {
-    const a = createTask(db, { description: "A" });
+    const a = createTask(db, userId, { description: "A" });
     expect(getDependencies(db, a.id)).toHaveLength(0);
   });
 });
 
 describe("getDependents", () => {
   it("returns all tasks that depend on a task", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
     addDependency(db, b.id, a.id);
     addDependency(db, c.id, a.id);
 
@@ -151,22 +153,22 @@ describe("getDependents", () => {
 
 describe("hasCycle", () => {
   it("returns false for valid dependency", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     expect(hasCycle(db, a.id, b.id)).toBe(false);
   });
 
   it("returns true for direct cycle", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
     expect(hasCycle(db, b.id, a.id)).toBe(true);
   });
 
   it("returns true for transitive cycle", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
     addDependency(db, a.id, b.id);
     addDependency(db, b.id, c.id);
     expect(hasCycle(db, c.id, a.id)).toBe(true);
@@ -175,8 +177,8 @@ describe("hasCycle", () => {
 
 describe("updateBlockedStatus", () => {
   it("unblocks task when all dependencies completed", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
     expect(getTask(db, a.id)?.status).toBe("blocked");
 
@@ -187,9 +189,9 @@ describe("updateBlockedStatus", () => {
   });
 
   it("keeps task blocked when unresolved dependencies remain", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
-    const c = createTask(db, { description: "C" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
+    const c = createTask(db, userId, { description: "C" });
     addDependency(db, a.id, b.id);
     addDependency(db, a.id, c.id);
 
@@ -200,8 +202,8 @@ describe("updateBlockedStatus", () => {
   });
 
   it("treats cancelled dependencies as resolved", () => {
-    const a = createTask(db, { description: "A" });
-    const b = createTask(db, { description: "B" });
+    const a = createTask(db, userId, { description: "A" });
+    const b = createTask(db, userId, { description: "B" });
     addDependency(db, a.id, b.id);
 
     updateTask(db, b.id, { status: "cancelled" });
@@ -211,9 +213,9 @@ describe("updateBlockedStatus", () => {
   });
 
   it("unblocks multiple dependents when a shared dependency is deleted", () => {
-    const dep = createTask(db, { description: "Shared" });
-    const t1 = createTask(db, { description: "T1" });
-    const t2 = createTask(db, { description: "T2" });
+    const dep = createTask(db, userId, { description: "Shared" });
+    const t1 = createTask(db, userId, { description: "T1" });
+    const t2 = createTask(db, userId, { description: "T2" });
     addDependency(db, t1.id, dep.id);
     addDependency(db, t2.id, dep.id);
     expect(getTask(db, t1.id)?.status).toBe("blocked");

--- a/tests/core/recurrence.test.ts
+++ b/tests/core/recurrence.test.ts
@@ -62,6 +62,7 @@ describe("getNextOccurrence", () => {
 describe("getNextTaskData", () => {
   const baseTask: Task = {
     id: 1,
+    userId: 1,
     description: "Weekly review",
     status: "done",
     category: "Work",

--- a/tests/core/task.test.ts
+++ b/tests/core/task.test.ts
@@ -8,18 +8,21 @@ import {
   updateTask,
 } from "@/core/task";
 import type { Db } from "@/core/types";
-import { createTestDb } from "../helpers";
+import { createTestDb, createTestUser } from "../helpers";
 
 let db: Db;
+let userId: number;
 
 beforeEach(() => {
   db = createTestDb();
+  userId = createTestUser(db).id;
 });
 
 describe("createTask", () => {
   it("creates a task with defaults", () => {
-    const task = createTask(db, { description: "Buy groceries" });
+    const task = createTask(db, userId, { description: "Buy groceries" });
     expect(task.id).toBe(1);
+    expect(task.userId).toBe(userId);
     expect(task.description).toBe("Buy groceries");
     expect(task.status).toBe("pending");
     expect(task.category).toBe("Todo");
@@ -34,7 +37,7 @@ describe("createTask", () => {
   });
 
   it("creates a task with all fields", () => {
-    const task = createTask(db, {
+    const task = createTask(db, userId, {
       description: "Review PR",
       status: "wip",
       category: "Open Source",
@@ -57,15 +60,15 @@ describe("createTask", () => {
   });
 
   it("auto-increments ids", () => {
-    const t1 = createTask(db, { description: "First" });
-    const t2 = createTask(db, { description: "Second" });
+    const t1 = createTask(db, userId, { description: "First" });
+    const t2 = createTask(db, userId, { description: "Second" });
     expect(t2.id).toBe(t1.id + 1);
   });
 });
 
 describe("getTask", () => {
   it("returns task by id", () => {
-    const created = createTask(db, { description: "Test" });
+    const created = createTask(db, userId, { description: "Test" });
     const found = getTask(db, created.id);
     expect(found).toEqual(created);
   });
@@ -77,21 +80,21 @@ describe("getTask", () => {
 
 describe("listTasks", () => {
   beforeEach(() => {
-    createTask(db, {
+    createTask(db, userId, {
       description: "A",
       status: "pending",
       category: "Work",
       priority: 1,
       due: "2026-04-01T00:00:00.000Z",
     });
-    createTask(db, {
+    createTask(db, userId, {
       description: "B",
       status: "done",
       category: "Personal",
       priority: 3,
       due: "2026-03-15T00:00:00.000Z",
     });
-    createTask(db, {
+    createTask(db, userId, {
       description: "C",
       status: "pending",
       category: "Work",
@@ -100,28 +103,35 @@ describe("listTasks", () => {
     });
   });
 
-  it("returns all tasks", () => {
-    expect(listTasks(db)).toHaveLength(3);
+  it("returns all tasks for user", () => {
+    expect(listTasks(db, userId)).toHaveLength(3);
+  });
+
+  it("does not return other users tasks", () => {
+    const other = createTestUser(db);
+    createTask(db, other.id, { description: "Other" });
+    expect(listTasks(db, userId)).toHaveLength(3);
+    expect(listTasks(db, other.id)).toHaveLength(1);
   });
 
   it("filters by status", () => {
-    const result = listTasks(db, { status: "pending" });
+    const result = listTasks(db, userId, { status: "pending" });
     expect(result).toHaveLength(2);
     expect(result.every((t) => t.status === "pending")).toBe(true);
   });
 
   it("filters by multiple statuses", () => {
-    const result = listTasks(db, { status: ["pending", "done"] });
+    const result = listTasks(db, userId, { status: ["pending", "done"] });
     expect(result).toHaveLength(3);
   });
 
   it("filters by category", () => {
-    const result = listTasks(db, { category: "Work" });
+    const result = listTasks(db, userId, { category: "Work" });
     expect(result).toHaveLength(2);
   });
 
   it("filters by due date range", () => {
-    const result = listTasks(db, {
+    const result = listTasks(db, userId, {
       dueAfter: "2026-03-20T00:00:00.000Z",
       dueBefore: "2026-04-15T00:00:00.000Z",
     });
@@ -130,25 +140,28 @@ describe("listTasks", () => {
   });
 
   it("filters by minimum priority", () => {
-    const result = listTasks(db, { minPriority: 2 });
+    const result = listTasks(db, userId, { minPriority: 2 });
     expect(result).toHaveLength(2);
   });
 
   it("sorts by priority descending", () => {
-    const result = listTasks(db, { sortBy: "priority", sortOrder: "desc" });
+    const result = listTasks(db, userId, {
+      sortBy: "priority",
+      sortOrder: "desc",
+    });
     expect(result[0].priority).toBe(3);
     expect(result[1].priority).toBe(2);
     expect(result[2].priority).toBe(1);
   });
 
   it("sorts by due date ascending", () => {
-    const result = listTasks(db, { sortBy: "due", sortOrder: "asc" });
+    const result = listTasks(db, userId, { sortBy: "due", sortOrder: "asc" });
     expect(result[0].description).toBe("B");
     expect(result[2].description).toBe("C");
   });
 
   it("combines status, category, and due range filters", () => {
-    const result = listTasks(db, {
+    const result = listTasks(db, userId, {
       status: "pending",
       category: "Work",
       dueAfter: "2026-03-20T00:00:00.000Z",
@@ -162,21 +175,22 @@ describe("listTasks", () => {
 });
 
 describe("updateTask", () => {
-  it("updates description", () => {
-    const task = createTask(db, { description: "Old" });
+  it("updates description", async () => {
+    const task = createTask(db, userId, { description: "Old" });
+    await new Promise((r) => setTimeout(r, 5));
     const updated = updateTask(db, task.id, { description: "New" });
     expect(updated.description).toBe("New");
     expect(updated.updatedAt).not.toBe(task.updatedAt);
   });
 
   it("sets completedAt when completing", () => {
-    const task = createTask(db, { description: "Test" });
+    const task = createTask(db, userId, { description: "Test" });
     const updated = updateTask(db, task.id, { status: "done" });
     expect(updated.completedAt).toBeTruthy();
   });
 
   it("clears completedAt when reopening", () => {
-    const task = createTask(db, { description: "Test" });
+    const task = createTask(db, userId, { description: "Test" });
     updateTask(db, task.id, { status: "done" });
     const reopened = updateTask(db, task.id, { status: "pending" });
     expect(reopened.completedAt).toBeNull();
@@ -189,7 +203,7 @@ describe("updateTask", () => {
   });
 
   it("updates an already-done task without changing completedAt", () => {
-    const task = createTask(db, { description: "Test" });
+    const task = createTask(db, userId, { description: "Test" });
     const done = updateTask(db, task.id, { status: "done" });
     const updated = updateTask(db, task.id, {
       description: "Updated done task",
@@ -200,20 +214,20 @@ describe("updateTask", () => {
   });
 
   it("re-completing an already-done task preserves completedAt", () => {
-    const task = createTask(db, { description: "Test" });
+    const task = createTask(db, userId, { description: "Test" });
     const done = updateTask(db, task.id, { status: "done" });
     const reDone = updateTask(db, task.id, { status: "done" });
     expect(reDone.completedAt).toBe(done.completedAt);
   });
 
   it("accepts empty string description via updateTask", () => {
-    const task = createTask(db, { description: "Original" });
+    const task = createTask(db, userId, { description: "Original" });
     const updated = updateTask(db, task.id, { description: "" });
     expect(updated.description).toBe("");
   });
 
   it("accepts negative priority via updateTask", () => {
-    const task = createTask(db, { description: "Test" });
+    const task = createTask(db, userId, { description: "Test" });
     const updated = updateTask(db, task.id, { priority: -1 });
     expect(updated.priority).toBe(-1);
   });
@@ -221,22 +235,22 @@ describe("updateTask", () => {
 
 describe("completeTask", () => {
   it("sets status to done with completedAt", () => {
-    const task = createTask(db, { description: "Test" });
-    const completed = completeTask(db, task.id);
+    const task = createTask(db, userId, { description: "Test" });
+    const completed = completeTask(db, userId, task.id);
     expect(completed.status).toBe("done");
     expect(completed.completedAt).toBeTruthy();
   });
 
   it("spawns recurring task on completion", () => {
-    createTask(db, {
+    createTask(db, userId, {
       description: "Weekly review",
       due: "2026-03-22T09:00:00.000Z",
       recurrence: "FREQ=WEEKLY",
       recurMode: "scheduled",
     });
-    completeTask(db, 1);
+    completeTask(db, userId, 1);
 
-    const all = listTasks(db);
+    const all = listTasks(db, userId);
     expect(all).toHaveLength(2);
 
     const spawned = all.find((t) => t.status === "pending");
@@ -251,7 +265,7 @@ describe("completeTask", () => {
 
 describe("deleteTask", () => {
   it("soft deletes by setting status to cancelled", () => {
-    const task = createTask(db, { description: "Test" });
+    const task = createTask(db, userId, { description: "Test" });
     const deleted = deleteTask(db, task.id);
     expect(deleted.status).toBe("cancelled");
     expect(deleted.completedAt).toBeTruthy();

--- a/tests/core/urgency.test.ts
+++ b/tests/core/urgency.test.ts
@@ -3,9 +3,10 @@ import { addDependency } from "@/core/dag";
 import { createTask, listTasks, updateTask } from "@/core/task";
 import type { Db, Task } from "@/core/types";
 import { computeUrgency, rankTasks } from "@/core/urgency";
-import { createTestDb } from "../helpers";
+import { createTestDb, createTestUser } from "../helpers";
 
 let db: Db;
+let userId: number;
 
 function daysFromNow(n: number): string {
   const d = new Date();
@@ -16,6 +17,7 @@ function daysFromNow(n: number): string {
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
     id: 1,
+    userId: 1,
     description: "Test",
     status: "pending",
     category: "Todo",
@@ -116,19 +118,20 @@ describe("computeUrgency", () => {
 describe("rankTasks", () => {
   beforeEach(() => {
     db = createTestDb();
+    userId = createTestUser(db).id;
   });
 
   it("sorts tasks by urgency descending", () => {
-    createTask(db, { description: "Low", priority: 0 });
-    createTask(db, {
+    createTask(db, userId, { description: "Low", priority: 0 });
+    createTask(db, userId, {
       description: "Urgent",
       priority: 3,
       due: daysFromNow(1),
       status: "wip",
     });
-    createTask(db, { description: "Medium", priority: 2 });
+    createTask(db, userId, { description: "Medium", priority: 2 });
 
-    const tasks = listTasks(db);
+    const tasks = listTasks(db, userId);
     const ranked = rankTasks(db, tasks);
 
     expect(ranked[0].description).toBe("Urgent");
@@ -138,28 +141,28 @@ describe("rankTasks", () => {
   });
 
   it("excludes done and cancelled tasks", () => {
-    createTask(db, { description: "Active", priority: 1 });
-    const done = createTask(db, { description: "Done" });
+    createTask(db, userId, { description: "Active", priority: 1 });
+    const done = createTask(db, userId, { description: "Done" });
     updateTask(db, done.id, { status: "done" });
 
-    const tasks = listTasks(db);
+    const tasks = listTasks(db, userId);
     const ranked = rankTasks(db, tasks);
 
     expect(ranked.every((t) => t.status !== "done")).toBe(true);
   });
 
   it("accounts for blocking relationships", () => {
-    const blocker = createTask(db, {
+    const blocker = createTask(db, userId, {
       description: "Blocker",
       priority: 1,
     });
-    const dependent = createTask(db, {
+    const dependent = createTask(db, userId, {
       description: "Dependent",
       priority: 1,
     });
     addDependency(db, dependent.id, blocker.id);
 
-    const tasks = listTasks(db);
+    const tasks = listTasks(db, userId);
     const ranked = rankTasks(db, tasks);
 
     const blockerRank = ranked.find((t) => t.id === blocker.id);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,8 @@
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { createUser } from "@/core/auth";
+import type { Db } from "@/core/types";
 import * as schema from "@/db/schema";
 
 export function createTestDb() {
@@ -9,4 +11,15 @@ export function createTestDb() {
   const db = drizzle(sqlite, { schema });
   migrate(db, { migrationsFolder: "./drizzle" });
   return db;
+}
+
+let userCounter = 0;
+
+export function createTestUser(db: Db, username?: string) {
+  userCounter++;
+  return createUser(
+    db,
+    username ?? `testuser${userCounter}`,
+    "testpassword123",
+  );
 }


### PR DESCRIPTION
## Problem

All tasks, automations, and category colors were global — any authenticated user could see and modify any other user's data. The auth gate existed but there was no data isolation behind it. Server actions had zero auth checks.

## Solution

Add `userId` FK to `tasks`, `automations`, and `categoryColors` tables with a migration that defaults existing rows to user 1. Thread `userId` through all core functions, server actions (with `requireUser`/`requireOwnedTask` helpers), API routes (ownership verification before mutations), and dashboard pages. Closes #24.