### PR TITLE
fix(ui): uppercase view shortcuts, overlay fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@
 next-env.d.ts
 
 .ai-docs/
+.claude/
 CLAUDE.md
 AGENTS.md

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import {
   Calendar,
-  CheckSquare,
   Columns3,
   type LucideIcon,
   Palette,
@@ -27,10 +26,10 @@ import {
 
 const views: { label: string; href: string; icon: LucideIcon; key: string }[] =
   [
-    { label: "Queue", href: "/", icon: Zap, key: "1" },
-    { label: "Kanban", href: "/kanban", icon: Columns3, key: "2" },
-    { label: "Calendar", href: "/calendar", icon: Calendar, key: "3" },
-    { label: "Settings", href: "/settings", icon: Settings, key: "4" },
+    { label: "Queue", href: "/", icon: Zap, key: "Q" },
+    { label: "Kanban", href: "/kanban", icon: Columns3, key: "K" },
+    { label: "Calendar", href: "/calendar", icon: Calendar, key: "C" },
+    { label: "Settings", href: "/settings", icon: Settings, key: "S" },
   ];
 
 export function AppSidebar({
@@ -82,21 +81,12 @@ export function AppSidebar({
           <SidebarGroupLabel>Categories</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/" />}
-                  isActive={pathname === "/" && !activeCategory}
-                >
-                  <CheckSquare className="size-4" />
-                  <span>All</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
               {categories.map((cat, idx) => {
-                const KEYS = ["5", "6", "7", "8", "9"];
+                const KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
                 const shortcutKey = idx < KEYS.length ? KEYS[idx] : null;
                 return (
                   <SidebarMenuItem key={cat}>
-                    <div className="flex items-center">
+                    <div className="relative">
                       <SidebarMenuButton
                         render={
                           <Link
@@ -104,7 +94,6 @@ export function AppSidebar({
                           />
                         }
                         isActive={activeCategory === cat}
-                        className="flex-1"
                       >
                         <span
                           className="text-xs font-bold shrink-0"
@@ -124,7 +113,7 @@ export function AppSidebar({
                       </SidebarMenuButton>
                       <button
                         type="button"
-                        className="p-1 rounded hover:bg-accent transition-colors opacity-0 group-hover/sidebar:opacity-100"
+                        className="absolute right-0 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-accent transition-colors opacity-0 group-hover/sidebar:opacity-100"
                         onClick={(e) => {
                           e.stopPropagation();
                           setEditingColor(editingColor === cat ? null : cat);

--- a/src/components/global-keyboard.tsx
+++ b/src/components/global-keyboard.tsx
@@ -16,8 +16,13 @@ function isInputFocused(): boolean {
   );
 }
 
-const viewRoutes = ["/", "/kanban", "/calendar", "/settings"];
-const CATEGORY_KEYS = ["5", "6", "7", "8", "9"];
+const VIEW_KEYS: Record<string, string> = {
+  Q: "/",
+  K: "/kanban",
+  C: "/calendar",
+  S: "/settings",
+};
+const CATEGORY_KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
 export function GlobalKeyboard({ categories = [] }: { categories?: string[] }) {
   const router = useRouter();
@@ -27,13 +32,13 @@ export function GlobalKeyboard({ categories = [] }: { categories?: string[] }) {
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
 
-      if (e.key === "b") {
+      if (e.key === "b" && !document.querySelector("[role=dialog]")) {
         e.preventDefault();
         toggleSidebar();
         return;
       }
 
-      if (e.key === "q" && !e.ctrlKey && !e.metaKey) {
+      if (e.key === "q") {
         e.preventDefault();
         fetch("/api/auth/logout", { method: "POST" }).then(() => {
           router.push("/login");
@@ -41,17 +46,17 @@ export function GlobalKeyboard({ categories = [] }: { categories?: string[] }) {
         return;
       }
 
+      const viewRoute = VIEW_KEYS[e.key];
+      if (viewRoute) {
+        e.preventDefault();
+        router.push(viewRoute);
+        return;
+      }
+
       const catIdx = CATEGORY_KEYS.indexOf(e.key);
       if (catIdx !== -1 && catIdx < categories.length) {
         e.preventDefault();
         router.push(`/?category=${encodeURIComponent(categories[catIdx])}`);
-        return;
-      }
-
-      const viewIndex = Number(e.key) - 1;
-      if (viewIndex >= 0 && viewIndex < viewRoutes.length) {
-        e.preventDefault();
-        router.push(viewRoutes[viewIndex]);
       }
     },
     [router, toggleSidebar, categories],

--- a/src/components/keyboard-hints.tsx
+++ b/src/components/keyboard-hints.tsx
@@ -44,7 +44,7 @@ export function KeyboardHints() {
         </>
       )}
       <div className="flex-1" />
-      <Hint keys="1-4" label="views" />
+      <Hint keys="QKCS" label="views" />
       <Hint keys="b" label="sidebar" />
       <Hint keys="q" label="logout" />
     </div>

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -128,7 +128,7 @@ export function TaskDetail({
   return (
     <DialogPrimitive.Root open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/60 backdrop-blur-xl duration-150 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm duration-150 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
         <DialogPrimitive.Popup
           className="fixed inset-4 sm:inset-8 z-50 mx-auto max-w-3xl flex flex-col rounded-xl bg-card ring-1 ring-border/40 shadow-2xl duration-150 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-[0.97] data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-[0.97]"
           onKeyDown={handleKeyDown}
@@ -142,7 +142,7 @@ export function TaskDetail({
             />
           </div>
 
-          <div className="flex flex-1 overflow-hidden">
+          <div className="flex flex-1 min-h-0">
             <div className="flex-1 overflow-auto px-8 pb-8">
               <TiptapEditor
                 content={task.notes ?? null}


### PR DESCRIPTION
## Problem

View shortcuts used number keys 1-4, conflicting with category shortcuts. Task detail overlay had excessive blur, `overflow-hidden` clipped the native date picker, and pressing `b` toggled the sidebar behind the overlay.

## Solution

Use uppercase `QKCS` for view navigation, freeing `1-9` for categories. Reduce backdrop to `backdrop-blur-sm`, replace `overflow-hidden` with `min-h-0`, and guard sidebar toggle against firing when a dialog is open. Also gitignore `.claude/` worktree directory that was breaking biome.