### PR TITLE
feat(auth): add OAuth login for GitHub, Google, GitLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@
 next-env.d.ts
 
 .ai-docs/
+.claude/
 CLAUDE.md
 AGENTS.md

--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,6 @@
     }
   },
   "files": {
-    "includes": ["**", "!.next", "!drizzle", "!src/components/ui"]
+    "includes": ["**", "!.next", "!.claude", "!drizzle", "!src/components/ui"]
   }
 }

--- a/drizzle/0005_aromatic_kylun.sql
+++ b/drizzle/0005_aromatic_kylun.sql
@@ -1,0 +1,24 @@
+CREATE TABLE `accounts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`provider` text NOT NULL,
+	`provider_account_id` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `accounts_provider_provider_account_id_unique` ON `accounts` (`provider`,`provider_account_id`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`username` text NOT NULL,
+	`password_hash` text,
+	`api_key` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_users`("id", "username", "password_hash", "api_key", "created_at") SELECT "id", "username", "password_hash", "api_key", "created_at" FROM `users`;--> statement-breakpoint
+DROP TABLE `users`;--> statement-breakpoint
+ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_username_unique` ON `users` (`username`);--> statement-breakpoint
+CREATE UNIQUE INDEX `users_api_key_unique` ON `users` (`api_key`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,562 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "374afd73-e044-4701-a86d-62d96a8074d2",
+  "prevId": "b0bab8bc-4b02-4069-9b50-aa344360868d",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_provider_provider_account_id_unique": {
+          "name": "accounts_provider_provider_account_id_unique",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automations_user_id_users_id_fk": {
+          "name": "automations_user_id_users_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category_colors": {
+      "name": "category_colors",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_colors_user_id_users_id_fk": {
+          "name": "category_colors_user_id_users_id_fk",
+          "tableFrom": "category_colors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "category_colors_user_id_category_pk": {
+          "columns": [
+            "user_id",
+            "category"
+          ],
+          "name": "category_colors_user_id_category_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_dependencies": {
+      "name": "task_dependencies",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depends_on_id": {
+          "name": "depends_on_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_dependencies_task_id_tasks_id_fk": {
+          "name": "task_dependencies_task_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependencies_depends_on_id_tasks_id_fk": {
+          "name": "task_dependencies_depends_on_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "depends_on_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_dependencies_task_id_depends_on_id_pk": {
+          "columns": [
+            "task_id",
+            "depends_on_id"
+          ],
+          "name": "task_dependencies_task_id_depends_on_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recur_mode": {
+          "name": "recur_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_api_key_unique": {
+          "name": "users_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774234338600,
       "tag": "0004_even_red_shift",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1774237341309,
+      "tag": "0005_aromatic_kylun",
+      "breakpoints": true
     }
   ]
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,10 +1,20 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { SettingsForm } from "@/components/settings-form";
-import { validateSession } from "@/core/auth";
+import { userHasPassword, validateSession } from "@/core/auth";
+import type { OAuthProvider } from "@/core/oauth";
+import { getLinkedProviders } from "@/core/oauth";
 import { getSettings } from "@/core/settings";
 import { listTasks } from "@/core/task";
 import { db } from "@/db";
+
+const allProviders: OAuthProvider[] = ["github", "google", "gitlab"];
+
+function getAvailableProviders(): OAuthProvider[] {
+  return allProviders.filter(
+    (p) => !!process.env[`OAUTH_${p.toUpperCase()}_CLIENT_ID`],
+  );
+}
 
 export default async function SettingsPage() {
   const cookieStore = await cookies();
@@ -19,5 +29,17 @@ export default async function SettingsPage() {
     ...new Set(allTasks.map((t) => t.category).filter(Boolean)),
   ] as string[];
 
-  return <SettingsForm settings={settings} categories={categories} />;
+  const linkedProviders = getLinkedProviders(db, user.id);
+  const availableProviders = getAvailableProviders();
+  const hasPassword = userHasPassword(db, user.id);
+
+  return (
+    <SettingsForm
+      settings={settings}
+      categories={categories}
+      linkedProviders={linkedProviders}
+      availableProviders={availableProviders}
+      hasPassword={hasPassword}
+    />
+  );
 }

--- a/src/app/actions/accounts.ts
+++ b/src/app/actions/accounts.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { validateSession } from "@/core/auth";
+import {
+  getLinkedProviders,
+  type OAuthProvider,
+  unlinkAccount,
+} from "@/core/oauth";
+import { db } from "@/db";
+
+type ActionResult<T> = { data: T } | { error: string };
+
+async function getAuthenticatedUserId(): Promise<number | null> {
+  const cookieStore = await cookies();
+  const sessionId = cookieStore.get("session")?.value;
+  if (!sessionId) return null;
+  const user = validateSession(db, sessionId);
+  return user?.id ?? null;
+}
+
+export async function getLinkedProvidersAction(): Promise<
+  ActionResult<OAuthProvider[]>
+> {
+  try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) return { error: "Not authenticated" };
+    return { data: getLinkedProviders(db, userId) };
+  } catch (e) {
+    return {
+      error: e instanceof Error ? e.message : "Failed to get linked providers",
+    };
+  }
+}
+
+export async function unlinkAccountAction(
+  provider: OAuthProvider,
+): Promise<ActionResult<null>> {
+  try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) return { error: "Not authenticated" };
+    unlinkAccount(db, userId, provider);
+    return { data: null };
+  } catch (e) {
+    return {
+      error: e instanceof Error ? e.message : "Failed to unlink account",
+    };
+  }
+}

--- a/src/app/api/auth/[provider]/route.ts
+++ b/src/app/api/auth/[provider]/route.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from "node:crypto";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import type { OAuthProvider } from "@/core/oauth";
+
+interface ProviderConfig {
+  authorizeUrl: string;
+  scopes: string;
+}
+
+const providers: Record<OAuthProvider, ProviderConfig> = {
+  github: {
+    authorizeUrl: "https://github.com/login/oauth/authorize",
+    scopes: "read:user user:email",
+  },
+  google: {
+    authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    scopes: "openid email profile",
+  },
+  gitlab: {
+    authorizeUrl: "https://gitlab.com/oauth/authorize",
+    scopes: "read_user",
+  },
+};
+
+function getEnvVar(provider: OAuthProvider, key: string): string | undefined {
+  return process.env[`OAUTH_${provider.toUpperCase()}_${key}`];
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const { provider: providerParam } = await params;
+  const provider = providerParam as OAuthProvider;
+
+  const config = providers[provider];
+  if (!config) {
+    return NextResponse.json({ error: "Unknown provider" }, { status: 400 });
+  }
+
+  const clientId = getEnvVar(provider, "CLIENT_ID");
+  if (!clientId) {
+    return NextResponse.json(
+      { error: "Provider not configured" },
+      { status: 400 },
+    );
+  }
+
+  const state = randomBytes(32).toString("hex");
+  const cookieStore = await cookies();
+  cookieStore.set("oauth_state", state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 600,
+  });
+
+  const redirectBase =
+    process.env.OAUTH_REDIRECT_BASE_URL ?? "http://localhost:3000";
+  const redirectUri = `${redirectBase}/api/auth/callback/${provider}`;
+
+  const url = new URL(config.authorizeUrl);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("state", state);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", config.scopes);
+
+  return NextResponse.redirect(url.toString());
+}

--- a/src/app/api/auth/callback/[provider]/route.ts
+++ b/src/app/api/auth/callback/[provider]/route.ts
@@ -1,0 +1,176 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { createSession } from "@/core/auth";
+import {
+  findOrCreateUserFromOAuth,
+  type OAuthProfile,
+  type OAuthProvider,
+} from "@/core/oauth";
+import { db } from "@/db";
+
+interface TokenConfig {
+  tokenUrl: string;
+  userInfoUrl: string;
+  extractProfile: (data: Record<string, unknown>) => OAuthProfile;
+  tokenInHeader?: boolean;
+}
+
+const providers: Record<OAuthProvider, TokenConfig> = {
+  github: {
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    userInfoUrl: "https://api.github.com/user",
+    tokenInHeader: true,
+    extractProfile: (data) => ({
+      username: data.login as string,
+      email: (data.email as string) || undefined,
+    }),
+  },
+  google: {
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    userInfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    tokenInHeader: true,
+    extractProfile: (data) => ({
+      username: (data.name as string) || (data.email as string),
+      email: (data.email as string) || undefined,
+    }),
+  },
+  gitlab: {
+    tokenUrl: "https://gitlab.com/oauth/token",
+    userInfoUrl: "https://gitlab.com/api/v4/user",
+    tokenInHeader: true,
+    extractProfile: (data) => ({
+      username: data.username as string,
+      email: (data.email as string) || undefined,
+    }),
+  },
+};
+
+function getEnvVar(provider: OAuthProvider, key: string): string | undefined {
+  return process.env[`OAUTH_${provider.toUpperCase()}_${key}`];
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const { provider: providerParam } = await params;
+  const provider = providerParam as OAuthProvider;
+
+  const config = providers[provider];
+  if (!config) {
+    return NextResponse.redirect(
+      new URL("/login?error=unknown_provider", request.url),
+    );
+  }
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const errorParam = url.searchParams.get("error");
+
+  if (errorParam) {
+    return NextResponse.redirect(
+      new URL(`/login?error=${errorParam}`, request.url),
+    );
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(
+      new URL("/login?error=missing_params", request.url),
+    );
+  }
+
+  const cookieStore = await cookies();
+  const storedState = cookieStore.get("oauth_state")?.value;
+  cookieStore.delete("oauth_state");
+
+  if (!storedState || storedState !== state) {
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_state", request.url),
+    );
+  }
+
+  const clientId = getEnvVar(provider, "CLIENT_ID");
+  const clientSecret = getEnvVar(provider, "CLIENT_SECRET");
+
+  if (!clientId || !clientSecret) {
+    return NextResponse.redirect(
+      new URL("/login?error=provider_not_configured", request.url),
+    );
+  }
+
+  const redirectBase =
+    process.env.OAUTH_REDIRECT_BASE_URL ?? "http://localhost:3000";
+  const redirectUri = `${redirectBase}/api/auth/callback/${provider}`;
+
+  try {
+    const tokenRes = await fetch(config.tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: redirectUri,
+        grant_type: "authorization_code",
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      return NextResponse.redirect(
+        new URL("/login?error=token_exchange_failed", request.url),
+      );
+    }
+
+    const tokenData = (await tokenRes.json()) as Record<string, unknown>;
+    const accessToken = tokenData.access_token as string;
+
+    if (!accessToken) {
+      return NextResponse.redirect(
+        new URL("/login?error=no_access_token", request.url),
+      );
+    }
+
+    const userRes = await fetch(config.userInfoUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!userRes.ok) {
+      return NextResponse.redirect(
+        new URL("/login?error=user_info_failed", request.url),
+      );
+    }
+
+    const userData = (await userRes.json()) as Record<string, unknown>;
+    const providerAccountId = String(userData.id ?? userData.sub);
+    const profile = config.extractProfile(userData);
+
+    const user = findOrCreateUserFromOAuth(
+      db,
+      provider,
+      providerAccountId,
+      profile,
+    );
+
+    const sessionId = createSession(db, user.id);
+    cookieStore.set("session", sessionId, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 7 * 24 * 60 * 60,
+    });
+
+    return NextResponse.redirect(new URL("/", request.url));
+  } catch {
+    return NextResponse.redirect(
+      new URL("/login?error=oauth_failed", request.url),
+    );
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,77 +1,21 @@
-"use client";
+import { Suspense } from "react";
+import { LoginForm } from "@/components/login-form";
+import type { OAuthProvider } from "@/core/oauth";
 
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+const allProviders: OAuthProvider[] = ["github", "google", "gitlab"];
+
+function getAvailableProviders(): OAuthProvider[] {
+  return allProviders.filter(
+    (p) => !!process.env[`OAUTH_${p.toUpperCase()}_CLIENT_ID`],
+  );
+}
 
 export default function LoginPage() {
-  const router = useRouter();
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError("");
-    setLoading(true);
-
-    const res = await fetch("/api/auth/login", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, password }),
-    });
-
-    if (res.ok) {
-      router.push("/");
-      router.refresh();
-    } else {
-      const data = await res.json();
-      setError(data.error ?? "Login failed");
-    }
-    setLoading(false);
-  }
+  const availableProviders = getAvailableProviders();
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-background">
-      <div className="w-full max-w-xs rounded-lg border border-border/60 bg-card p-8 shadow-lg">
-        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-          <h1 className="text-5xl text-center text-foreground select-none font-serif">
-            &Delta;
-          </h1>
-          <p className="text-sm text-muted-foreground text-center -mt-2">
-            Sign in
-          </p>
-          {error && (
-            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive text-center">
-              {error}
-            </div>
-          )}
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="username">Username</Label>
-            <Input
-              id="username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              autoFocus
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="password">Password</Label>
-            <Input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-          <Button type="submit" disabled={loading} className="mt-1">
-            {loading ? "Signing in\u2026" : "Sign in"}
-          </Button>
-        </form>
-      </div>
-    </div>
+    <Suspense>
+      <LoginForm availableProviders={availableProviders} />
+    </Suspense>
   );
 }

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { OAuthProvider } from "@/core/oauth";
+
+const providerLabels: Record<OAuthProvider, string> = {
+  github: "GitHub",
+  google: "Google",
+  gitlab: "GitLab",
+};
+
+export function LoginForm({
+  availableProviders,
+}: {
+  availableProviders: OAuthProvider[];
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const oauthError = searchParams.get("error");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(oauthError ?? "");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password }),
+    });
+
+    if (res.ok) {
+      router.push("/");
+      router.refresh();
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Login failed");
+    }
+    setLoading(false);
+  }
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-background">
+      <div className="w-full max-w-xs rounded-lg border border-border/60 bg-card p-8 shadow-lg">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          <h1 className="text-5xl text-center text-foreground select-none font-serif">
+            &Delta;
+          </h1>
+          <p className="text-sm text-muted-foreground text-center -mt-2">
+            Sign in
+          </p>
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive text-center">
+              {error}
+            </div>
+          )}
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="mt-1">
+            {loading ? "Signing in\u2026" : "Sign in"}
+          </Button>
+        </form>
+        {availableProviders.length > 0 && (
+          <>
+            <div className="flex items-center gap-3 my-5">
+              <div className="h-px flex-1 bg-border/60" />
+              <span className="text-xs text-muted-foreground">or</span>
+              <div className="h-px flex-1 bg-border/60" />
+            </div>
+            <div className="flex flex-col gap-2">
+              {availableProviders.map((provider) => (
+                <Button
+                  key={provider}
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => {
+                    window.location.href = `/api/auth/${provider}`;
+                  }}
+                >
+                  Continue with {providerLabels[provider]}
+                </Button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings-form.tsx
+++ b/src/components/settings-form.tsx
@@ -3,6 +3,7 @@
 import { Settings } from "lucide-react";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
+import { unlinkAccountAction } from "@/app/actions/accounts";
 import { updateSettingsAction } from "@/app/actions/settings";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -15,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import type { OAuthProvider } from "@/core/oauth";
 import type {
   DateFormat,
   UserSettings,
@@ -22,6 +24,12 @@ import type {
   WeekStartDay,
 } from "@/core/settings";
 import { DEFAULT_SETTINGS } from "@/core/settings";
+
+const providerLabels: Record<OAuthProvider, string> = {
+  github: "GitHub",
+  google: "Google",
+  gitlab: "GitLab",
+};
 
 function Section({
   title,
@@ -83,11 +91,18 @@ function WeightInput({
 export function SettingsForm({
   settings: initial,
   categories,
+  linkedProviders: initialLinked = [],
+  availableProviders = [],
+  hasPassword = true,
 }: {
   settings: UserSettings;
   categories: string[];
+  linkedProviders?: OAuthProvider[];
+  availableProviders?: OAuthProvider[];
+  hasPassword?: boolean;
 }) {
   const [settings, setSettings] = useState<UserSettings>(initial);
+  const [linked, setLinked] = useState<OAuthProvider[]>(initialLinked);
   const [isPending, startTransition] = useTransition();
 
   function update(partial: Partial<UserSettings>) {
@@ -114,6 +129,18 @@ export function SettingsForm({
 
   function handleReset() {
     setSettings({ ...DEFAULT_SETTINGS });
+  }
+
+  function handleUnlink(provider: OAuthProvider) {
+    startTransition(async () => {
+      const result = await unlinkAccountAction(provider);
+      if ("error" in result) {
+        toast.error(result.error);
+      } else {
+        setLinked((prev) => prev.filter((p) => p !== provider));
+        toast.success(`Unlinked ${providerLabels[provider]}`);
+      }
+    });
   }
 
   return (
@@ -287,6 +314,51 @@ export function SettingsForm({
               }
             />
           </Section>
+
+          {availableProviders.length > 0 && (
+            <>
+              <div className="h-px bg-border/60" />
+
+              <Section title="Linked Accounts">
+                <div className="space-y-3">
+                  {availableProviders.map((provider) => {
+                    const isLinked = linked.includes(provider);
+                    const canUnlink = hasPassword || linked.length > 1;
+                    return (
+                      <div
+                        key={provider}
+                        className="flex items-center justify-between"
+                      >
+                        <span className="text-sm text-muted-foreground">
+                          {providerLabels[provider]}
+                        </span>
+                        {isLinked ? (
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            disabled={!canUnlink || isPending}
+                            onClick={() => handleUnlink(provider)}
+                          >
+                            Unlink
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              window.location.href = `/api/auth/${provider}`;
+                            }}
+                          >
+                            Link
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </Section>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -56,6 +56,7 @@ export function verifyPassword(
     .where(eq(users.username, username))
     .get();
   if (!user) return null;
+  if (!user.passwordHash) return null;
   if (!compareSync(password, user.passwordHash)) return null;
   return toSafeUser(user);
 }
@@ -101,6 +102,11 @@ export function validateApiKey(db: Db, apiKey: string): SafeUser | null {
   const user = db.select().from(users).where(eq(users.apiKey, apiKey)).get();
   if (!user) return null;
   return toSafeUser(user);
+}
+
+export function userHasPassword(db: Db, userId: number): boolean {
+  const user = db.select().from(users).where(eq(users.id, userId)).get();
+  return !!user?.passwordHash;
 }
 
 export function regenerateApiKey(db: Db, userId: number): string {

--- a/src/core/oauth.ts
+++ b/src/core/oauth.ts
@@ -1,0 +1,116 @@
+import { randomBytes } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { accounts, users } from "@/db/schema";
+import type { Db } from "./types";
+
+export type OAuthProvider = "github" | "google" | "gitlab";
+
+export interface OAuthProfile {
+  username: string;
+  email?: string;
+}
+
+export function findAccountByProvider(
+  db: Db,
+  provider: OAuthProvider,
+  providerAccountId: string,
+) {
+  return db
+    .select()
+    .from(accounts)
+    .where(
+      and(
+        eq(accounts.provider, provider),
+        eq(accounts.providerAccountId, providerAccountId),
+      ),
+    )
+    .get();
+}
+
+export function linkAccount(
+  db: Db,
+  userId: number,
+  provider: OAuthProvider,
+  providerAccountId: string,
+) {
+  return db
+    .insert(accounts)
+    .values({ userId, provider, providerAccountId })
+    .returning()
+    .get();
+}
+
+export function unlinkAccount(db: Db, userId: number, provider: OAuthProvider) {
+  const user = db.select().from(users).where(eq(users.id, userId)).get();
+  if (!user) throw new Error("User not found");
+
+  const linkedAccounts = db
+    .select()
+    .from(accounts)
+    .where(eq(accounts.userId, userId))
+    .all();
+
+  const hasPassword = !!user.passwordHash;
+  const otherAccounts = linkedAccounts.filter((a) => a.provider !== provider);
+
+  if (!hasPassword && otherAccounts.length === 0) {
+    throw new Error("Cannot unlink last auth method");
+  }
+
+  return db
+    .delete(accounts)
+    .where(and(eq(accounts.userId, userId), eq(accounts.provider, provider)))
+    .run();
+}
+
+export function getLinkedProviders(db: Db, userId: number): OAuthProvider[] {
+  return db
+    .select({ provider: accounts.provider })
+    .from(accounts)
+    .where(eq(accounts.userId, userId))
+    .all()
+    .map((a) => a.provider as OAuthProvider);
+}
+
+export function findOrCreateUserFromOAuth(
+  db: Db,
+  provider: OAuthProvider,
+  providerAccountId: string,
+  profile: OAuthProfile,
+) {
+  const existing = findAccountByProvider(db, provider, providerAccountId);
+  if (existing) {
+    const user = db
+      .select()
+      .from(users)
+      .where(eq(users.id, existing.userId))
+      .get();
+    if (!user) throw new Error("Linked user not found");
+    const { passwordHash: _, ...safe } = user;
+    return safe;
+  }
+
+  const baseUsername = profile.username;
+  let username = baseUsername;
+  let attempt = 0;
+  while (db.select().from(users).where(eq(users.username, username)).get()) {
+    attempt++;
+    username = `${baseUsername}${attempt}`;
+  }
+
+  const user = db
+    .insert(users)
+    .values({
+      username,
+      passwordHash: null,
+      apiKey: randomBytes(32).toString("hex"),
+      createdAt: new Date().toISOString(),
+    })
+    .returning()
+    .get();
+
+  linkAccount(db, user.id, provider, providerAccountId);
+
+  const { passwordHash: _, ...safe } = user;
+  return safe;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,15 +3,29 @@ import {
   primaryKey,
   sqliteTable,
   text,
+  unique,
 } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   username: text("username").notNull().unique(),
-  passwordHash: text("password_hash").notNull(),
+  passwordHash: text("password_hash"),
   apiKey: text("api_key").unique(),
   createdAt: text("created_at").notNull(),
 });
+
+export const accounts = sqliteTable(
+  "accounts",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    providerAccountId: text("provider_account_id").notNull(),
+  },
+  (t) => [unique().on(t.provider, t.providerAccountId)],
+);
 
 export const tasks = sqliteTable("tasks", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/tests/core/oauth.test.ts
+++ b/tests/core/oauth.test.ts
@@ -1,0 +1,144 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createUser } from "@/core/auth";
+import {
+  findAccountByProvider,
+  findOrCreateUserFromOAuth,
+  linkAccount,
+  unlinkAccount,
+} from "@/core/oauth";
+import type { Db } from "@/core/types";
+import { users } from "@/db/schema";
+import { createTestDb } from "../helpers";
+
+let db: Db;
+
+beforeEach(() => {
+  db = createTestDb();
+});
+
+describe("findOrCreateUserFromOAuth", () => {
+  it("creates user on first login", () => {
+    const user = findOrCreateUserFromOAuth(db, "github", "gh-123", {
+      username: "barrett",
+      email: "b@example.com",
+    });
+
+    expect(user.id).toBe(1);
+    expect(user.username).toBe("barrett");
+    expect("passwordHash" in user).toBe(false);
+
+    const account = findAccountByProvider(db, "github", "gh-123");
+    expect(account).not.toBeNull();
+    expect(account?.userId).toBe(user.id);
+  });
+
+  it("returns existing user on subsequent login", () => {
+    const first = findOrCreateUserFromOAuth(db, "github", "gh-123", {
+      username: "barrett",
+    });
+    const second = findOrCreateUserFromOAuth(db, "github", "gh-123", {
+      username: "barrett",
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.username).toBe(first.username);
+  });
+
+  it("deduplicates username with numeric suffix", () => {
+    createUser(db, "barrett", "password123");
+
+    const oauthUser = findOrCreateUserFromOAuth(db, "github", "gh-456", {
+      username: "barrett",
+    });
+
+    expect(oauthUser.username).toBe("barrett1");
+  });
+
+  it("creates user without email", () => {
+    const user = findOrCreateUserFromOAuth(db, "google", "g-789", {
+      username: "someone",
+    });
+
+    expect(user.username).toBe("someone");
+  });
+});
+
+describe("linkAccount", () => {
+  it("links an OAuth provider to a user", () => {
+    const user = createUser(db, "barrett", "password123");
+    const account = linkAccount(db, user.id, "github", "gh-123");
+
+    expect(account.provider).toBe("github");
+    expect(account.providerAccountId).toBe("gh-123");
+    expect(account.userId).toBe(user.id);
+
+    const found = findAccountByProvider(db, "github", "gh-123");
+    expect(found).not.toBeNull();
+    expect(found?.userId).toBe(user.id);
+  });
+
+  it("allows multiple providers per user", () => {
+    const user = createUser(db, "barrett", "password123");
+    linkAccount(db, user.id, "github", "gh-123");
+    linkAccount(db, user.id, "google", "g-456");
+
+    const ghAccount = findAccountByProvider(db, "github", "gh-123");
+    const gAccount = findAccountByProvider(db, "google", "g-456");
+
+    expect(ghAccount?.userId).toBe(user.id);
+    expect(gAccount?.userId).toBe(user.id);
+  });
+
+  it("rejects duplicate provider + providerAccountId", () => {
+    const user1 = createUser(db, "user1", "password123");
+    const user2 = createUser(db, "user2", "password456");
+
+    linkAccount(db, user1.id, "github", "gh-123");
+    expect(() => linkAccount(db, user2.id, "github", "gh-123")).toThrow();
+  });
+});
+
+describe("unlinkAccount", () => {
+  it("removes a linked provider", () => {
+    const user = createUser(db, "barrett", "password123");
+    linkAccount(db, user.id, "github", "gh-123");
+
+    unlinkAccount(db, user.id, "github");
+
+    const found = findAccountByProvider(db, "github", "gh-123");
+    expect(found).toBeUndefined();
+  });
+
+  it("allows unlink when user has password", () => {
+    const user = createUser(db, "barrett", "password123");
+    linkAccount(db, user.id, "github", "gh-123");
+
+    expect(() => unlinkAccount(db, user.id, "github")).not.toThrow();
+  });
+
+  it("allows unlink when user has other linked providers", () => {
+    const user = findOrCreateUserFromOAuth(db, "github", "gh-123", {
+      username: "barrett",
+    });
+    linkAccount(db, user.id, "google", "g-456");
+
+    expect(() => unlinkAccount(db, user.id, "github")).not.toThrow();
+
+    const found = findAccountByProvider(db, "github", "gh-123");
+    expect(found).toBeUndefined();
+  });
+
+  it("throws when unlinking last auth method with no password", () => {
+    const user = findOrCreateUserFromOAuth(db, "github", "gh-123", {
+      username: "barrett",
+    });
+
+    const dbUser = db.select().from(users).where(eq(users.id, user.id)).get();
+    expect(dbUser?.passwordHash).toBeNull();
+
+    expect(() => unlinkAccount(db, user.id, "github")).toThrow(
+      "Cannot unlink last auth method",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Auth is username/password only. Friends who want to use delta need manually-created credentials. Closes #28.

## Solution

Add OAuth 2.0 authorization code flow for GitHub, Google, and GitLab — no external libraries. Each provider is configured via `OAUTH_{PROVIDER}_CLIENT_ID` and `OAUTH_{PROVIDER}_CLIENT_SECRET` env vars; unconfigured providers are hidden from the login page.

New `accounts` table links provider identities to users. `passwordHash` is now nullable so OAuth-only users can exist. CSRF protection via random state cookie. Username deduplication on first OAuth login. Settings page lets users link/unlink providers (with guard against removing the last auth method). 11 new tests (209 total).