### PR TITLE
fix(ui): restore lost changes, add github_dev recipe

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -121,6 +121,7 @@ export function CalendarView({
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [createDate, setCreateDate] = useState<string>("");
+  const [selectedDayIdx, setSelectedDayIdx] = useState(-1);
   const pendingBracket = useRef<"[" | "]" | null>(null);
   const bracketTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [today, setToday] = useState(() => new Date());
@@ -198,6 +199,31 @@ export function CalendarView({
         return;
       }
 
+      if (viewMode === "week" && e.key === "h") {
+        e.preventDefault();
+        setSelectedDayIdx((i) => {
+          const cur = i < 0 ? 0 : i;
+          if (cur === 0) {
+            prevWeek();
+            return 6;
+          }
+          return cur - 1;
+        });
+        return;
+      }
+      if (viewMode === "week" && e.key === "l") {
+        e.preventDefault();
+        setSelectedDayIdx((i) => {
+          const cur = i < 0 ? 0 : i;
+          if (cur === 6) {
+            nextWeek();
+            return 0;
+          }
+          return cur + 1;
+        });
+        return;
+      }
+
       if (e.key === "[" || e.key === "]") {
         e.preventDefault();
         pendingBracket.current = e.key;
@@ -224,7 +250,7 @@ export function CalendarView({
         return;
       }
     },
-    [prevWeek, nextWeek, prevMonth, nextMonth, goToday],
+    [viewMode, prevWeek, nextWeek, prevMonth, nextMonth, goToday],
   );
 
   useEffect(() => {
@@ -317,6 +343,7 @@ export function CalendarView({
           onTaskClick={setSelectedTask}
           dayNames={DAY_NAMES}
           categoryColors={categoryColors}
+          selectedDayIdx={selectedDayIdx}
         />
       ) : (
         <MonthView
@@ -354,6 +381,7 @@ function WeekView({
   onTaskClick,
   dayNames,
   categoryColors,
+  selectedDayIdx,
 }: {
   weekStart: Date;
   today: Date;
@@ -362,6 +390,7 @@ function WeekView({
   onTaskClick: (task: Task) => void;
   dayNames: string[];
   categoryColors: Record<string, string>;
+  selectedDayIdx: number;
 }) {
   const days = useMemo(() => {
     const result: Date[] = [];
@@ -376,19 +405,18 @@ function WeekView({
       <div className="grid grid-cols-7 border-b border-border/60 shrink-0">
         {days.map((date, idx) => {
           const isToday = isSameDay(date, today);
+          const isSelected = idx === selectedDayIdx;
           return (
             <div
               key={formatDateKey(date)}
-              className={`flex flex-col items-center py-2 ${isToday ? "bg-primary/5" : ""}`}
+              className={`flex flex-col items-center py-2 ${isSelected ? "bg-accent" : isToday ? "bg-primary/5" : ""}`}
             >
               <span className="text-xs text-muted-foreground">
                 {dayNames[idx]}
               </span>
               <span
                 className={`text-sm font-semibold mt-0.5 ${
-                  isToday
-                    ? "bg-primary text-primary-foreground w-7 h-7 flex items-center justify-center"
-                    : "text-foreground"
+                  isToday ? "text-primary" : "text-foreground"
                 }`}
               >
                 {date.getDate()}
@@ -398,17 +426,18 @@ function WeekView({
         })}
       </div>
       <div className="grid grid-cols-7 flex-1 overflow-auto">
-        {days.map((date) => {
+        {days.map((date, idx) => {
           const key = formatDateKey(date);
           const dayTasks = tasksByDate.get(key) ?? [];
           const isToday = isSameDay(date, today);
+          const isSelected = idx === selectedDayIdx;
 
           const blend = dayBlendStyle(dayTasks, categoryColors);
           return (
             <div
               key={key}
               className={`flex flex-col p-2 border-r border-border/30 ${
-                isToday ? "bg-primary/5" : ""
+                isSelected ? "bg-accent" : isToday ? "bg-primary/5" : ""
               }`}
               style={!isToday ? blend : undefined}
             >
@@ -421,7 +450,7 @@ function WeekView({
                     onClick={() => onTaskClick(task)}
                   >
                     <span
-                      className={`shrink-0 mt-1 w-1.5 h-1.5 rounded-full ${statusDot(task)}`}
+                      className={`shrink-0 mt-1 w-1.5 h-1.5 ${statusDot(task)}`}
                     />
                     <span className="truncate">{task.description}</span>
                   </button>
@@ -509,8 +538,8 @@ function MonthView({
             <div
               key={cell.key}
               className={`flex flex-col p-1.5 text-left transition-colors border-b border-r border-border/30 ${
-                isToday ? "ring-1 ring-primary/50" : ""
-              } ${isPast ? "opacity-50" : ""}`}
+                isPast ? "opacity-50" : ""
+              }`}
               style={blend}
             >
               <span
@@ -529,7 +558,7 @@ function MonthView({
                     onClick={() => onTaskClick(task)}
                   >
                     <span
-                      className={`shrink-0 mt-[3px] w-1.5 h-1.5 rounded-full ${statusDot(task)}`}
+                      className={`shrink-0 mt-[3px] w-1.5 h-1.5 ${statusDot(task)}`}
                     />
                     <span className="truncate">{task.description}</span>
                   </button>

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   completeTaskAction,
   deleteTaskAction,
@@ -53,7 +53,25 @@ export function TaskDetail({
   const [category, setCategory] = useState("");
   const [priority, setPriority] = useState("0");
   const [due, setDue] = useState("");
+  const [showCategorySuggestions, setShowCategorySuggestions] = useState(false);
   const notesRef = useRef<string | null>(null);
+
+  const allCategories = useMemo(() => {
+    if (!tasks) return [];
+    const cats = new Set<string>();
+    for (const t of tasks) {
+      if (t.category) cats.add(t.category);
+    }
+    return [...cats].sort();
+  }, [tasks]);
+
+  const filteredCategories = useMemo(() => {
+    if (!category) return allCategories;
+    const lower = category.toLowerCase();
+    return allCategories.filter(
+      (c) => c.toLowerCase().includes(lower) && c !== category,
+    );
+  }, [allCategories, category]);
 
   useEffect(() => {
     if (task) {
@@ -167,24 +185,51 @@ export function TaskDetail({
               </SelectContent>
             </Select>
 
-            <Input
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              placeholder="category"
-              className="h-7 w-28 text-xs"
-            />
+            <div className="relative">
+              <Input
+                value={category}
+                onChange={(e) => {
+                  setCategory(e.target.value);
+                  setShowCategorySuggestions(true);
+                }}
+                onFocus={() => setShowCategorySuggestions(true)}
+                onBlur={() =>
+                  setTimeout(() => setShowCategorySuggestions(false), 150)
+                }
+                placeholder="category"
+                className="h-8 w-28 text-xs"
+              />
+              {showCategorySuggestions && filteredCategories.length > 0 && (
+                <div className="absolute top-full left-0 right-0 mt-1 z-50 border border-border bg-popover py-1">
+                  {filteredCategories.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      className="w-full px-2 py-1 text-xs text-left hover:bg-accent transition-colors"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        setCategory(c);
+                        setShowCategorySuggestions(false);
+                      }}
+                    >
+                      {c}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
 
             <Input
               type="datetime-local"
               value={due}
               onChange={(e) => setDue(e.target.value)}
-              className="h-7 w-auto text-xs"
+              className="h-8 w-auto text-xs"
             />
 
             <div className="flex-1" />
 
             {task.createdAt && (
-              <span className="text-[10px] text-muted-foreground/60 tabular-nums">
+              <span className="text-xs text-muted-foreground/60 tabular-nums">
                 {formatDate(new Date(task.createdAt))}
               </span>
             )}
@@ -203,7 +248,7 @@ export function TaskDetail({
             <Button size="sm" onClick={handleSave}>
               Save
             </Button>
-            <span className="text-[10px] text-muted-foreground">Ctrl+S</span>
+            <span className="text-xs text-muted-foreground">Ctrl+S</span>
             <div className="flex-1" />
             <Button size="sm" variant="destructive" onClick={handleDelete}>
               Delete

--- a/src/components/tiptap-editor.tsx
+++ b/src/components/tiptap-editor.tsx
@@ -109,7 +109,7 @@ export function TiptapEditor({
     extensions: [
       StarterKit.configure({ codeBlock: false }),
       CodeBlockShiki.configure({
-        defaultTheme: "midnight",
+        themes: { light: "daylight", dark: "midnight" } as never,
         defaultLanguage: null,
         customThemes: [midnight, daylight],
       }),

--- a/src/components/tiptap-styles.css
+++ b/src/components/tiptap-styles.css
@@ -99,6 +99,13 @@
   font-weight: 600;
 }
 
+.tiptap pre.shiki,
+.tiptap pre.shiki code,
+.tiptap pre.shiki code span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+
 html.dark .tiptap pre.shiki,
 html.dark .tiptap pre.shiki code,
 html.dark .tiptap pre.shiki code span {

--- a/src/core/automation.ts
+++ b/src/core/automation.ts
@@ -91,6 +91,8 @@ let _recipesLoaded = false;
 export async function loadBuiltinRecipes(): Promise<void> {
   if (_recipesLoaded) return;
   const { githubIssuesHandler } = await import("./recipes/github-issues");
+  const { githubDevHandler } = await import("./recipes/github-dev");
   registerRecipe("github_issues", githubIssuesHandler);
+  registerRecipe("github_dev", githubDevHandler);
   _recipesLoaded = true;
 }

--- a/src/core/recipes/github-dev.ts
+++ b/src/core/recipes/github-dev.ts
@@ -1,0 +1,125 @@
+import { like } from "drizzle-orm";
+import { createTask } from "@/core/task";
+import type { Db } from "@/core/types";
+import { tasks } from "@/db/schema";
+
+interface GitHubDevConfig {
+  token: string;
+  category?: string;
+}
+
+interface GitHubRepo {
+  full_name: string;
+  archived: boolean;
+  disabled: boolean;
+}
+
+interface GitHubItem {
+  number: number;
+  title: string;
+  pull_request?: unknown;
+  state: string;
+}
+
+function isValidConfig(config: unknown): config is GitHubDevConfig {
+  if (typeof config !== "object" || config === null) return false;
+  const c = config as Record<string, unknown>;
+  return typeof c.token === "string";
+}
+
+function formatDescription(
+  repo: string,
+  title: string,
+  number: number,
+  isPR: boolean,
+): string {
+  const prefix = isPR ? "PR" : "issue";
+  return `[${repo}] ${title} (${prefix} #${number})`;
+}
+
+function taskExists(db: Db, repo: string, number: number): boolean {
+  const pattern = `[${repo}]%(#${number})`;
+  return (
+    db.select().from(tasks).where(like(tasks.description, pattern)).get() !==
+    undefined
+  );
+}
+
+async function ghFetch<T>(url: string, token: string): Promise<T> {
+  const items: unknown[] = [];
+  let nextUrl: string | null = url;
+
+  while (nextUrl) {
+    const response: Response = await fetch(nextUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status} ${nextUrl}`);
+    }
+    const data = await response.json();
+    if (Array.isArray(data)) {
+      items.push(...data);
+    } else {
+      return data as T;
+    }
+
+    const link: string | null = response.headers.get("link");
+    nextUrl = null;
+    if (link) {
+      const match: RegExpMatchArray | null = link.match(
+        /<([^>]+)>;\s*rel="next"/,
+      );
+      if (match) nextUrl = match[1];
+    }
+  }
+
+  return items as T;
+}
+
+export async function githubDevHandler(
+  db: Db,
+  userId: number,
+  config: unknown,
+): Promise<void> {
+  if (!isValidConfig(config)) {
+    throw new Error("Invalid github_dev config");
+  }
+
+  const category = config.category ?? "dev";
+  const repos = await ghFetch<GitHubRepo[]>(
+    "https://api.github.com/user/repos?per_page=100&sort=pushed",
+    config.token,
+  );
+
+  const activeRepos = repos.filter((r) => !r.archived && !r.disabled);
+
+  for (const repo of activeRepos) {
+    let items: GitHubItem[];
+    try {
+      items = await ghFetch<GitHubItem[]>(
+        `https://api.github.com/repos/${repo.full_name}/issues?state=open&per_page=100`,
+        config.token,
+      );
+    } catch {
+      continue;
+    }
+
+    for (const item of items) {
+      const isPR = !!item.pull_request;
+      if (taskExists(db, repo.full_name, item.number)) continue;
+
+      createTask(db, userId, {
+        description: formatDescription(
+          repo.full_name,
+          item.title,
+          item.number,
+          isPR,
+        ),
+        category,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Several UI changes from the previous session were silently lost during squash merges — shiki dual theme, calendar dot shapes, today ring removal, h/l week navigation, task detail category combobox, and input sizing never landed on main.

## Solution

Restore all missing changes and add `github_dev` automation recipe:

- Shiki: dual theme (`light`/`dark`) instead of `defaultTheme`, light mode CSS rules
- Calendar: square status dots, no today ring in month view, simplified today header in week, h/l day navigation with week auto-advance
- Task detail: category combobox (type + dropdown), `h-8` inputs, `text-xs` date/hint text
- New `github_dev` recipe: fetches all user repos, creates tasks for open issues AND PRs (including own), paginated