### PR TITLE
feat(ui): calendar hjkl nav, kanban column shortcuts

### DIFF
--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -19,7 +19,7 @@ const viewRoutes: Record<ViewType, string> = {
 export default async function QueuePage({
   searchParams,
 }: {
-  searchParams: Promise<{ category?: string; status?: string }>;
+  searchParams: Promise<{ category?: string; status?: string; date?: string }>;
 }) {
   const params = await searchParams;
   const cookieStore = await cookies();
@@ -33,7 +33,8 @@ export default async function QueuePage({
     settings.defaultView !== "queue" &&
     settings.defaultView !== "list" &&
     !params.category &&
-    !params.status
+    !params.status &&
+    !params.date
   ) {
     redirect(viewRoutes[settings.defaultView]);
   }
@@ -43,6 +44,10 @@ export default async function QueuePage({
   if (params.category) filters.category = params.category;
   if (params.status) {
     filters.status = params.status.split(",") as TaskStatus[];
+  }
+  if (params.date) {
+    filters.dueAfter = `${params.date}T00:00:00.000Z`;
+    filters.dueBefore = `${params.date}T23:59:59.999Z`;
   }
 
   if (!settings.showCompletedTasks && !params.status) {

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CreateTaskDialog } from "@/components/create-task-dialog";
 import { TaskDetail } from "@/components/task-detail";
@@ -121,8 +122,9 @@ export function CalendarView({
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [createDate, setCreateDate] = useState<string>("");
-  const [selectedDayIdx, setSelectedDayIdx] = useState(-1);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const pendingBracket = useRef<"[" | "]" | null>(null);
+  const router = useRouter();
   const bracketTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [today, setToday] = useState(() => new Date());
 
@@ -171,6 +173,15 @@ export function CalendarView({
     setAnchor(new Date());
   }, []);
 
+  const moveSelection = useCallback((days: number) => {
+    setSelectedDate((prev) => {
+      const base = prev ?? new Date();
+      const next = addDays(base, days);
+      setAnchor(next);
+      return next;
+    });
+  }, []);
+
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
@@ -199,28 +210,34 @@ export function CalendarView({
         return;
       }
 
-      if (viewMode === "week" && e.key === "h") {
+      if (e.key === "h") {
         e.preventDefault();
-        setSelectedDayIdx((i) => {
-          const cur = i < 0 ? 0 : i;
-          if (cur === 0) {
-            prevWeek();
-            return 6;
-          }
-          return cur - 1;
-        });
+        moveSelection(-1);
         return;
       }
-      if (viewMode === "week" && e.key === "l") {
+      if (e.key === "l") {
         e.preventDefault();
-        setSelectedDayIdx((i) => {
-          const cur = i < 0 ? 0 : i;
-          if (cur === 6) {
-            nextWeek();
-            return 0;
-          }
-          return cur + 1;
-        });
+        moveSelection(1);
+        return;
+      }
+      if (e.key === "j") {
+        e.preventDefault();
+        moveSelection(7);
+        return;
+      }
+      if (e.key === "k") {
+        e.preventDefault();
+        moveSelection(-7);
+        return;
+      }
+      if (e.key === "Enter" && selectedDate) {
+        e.preventDefault();
+        router.push(`/?date=${formatDateKey(selectedDate)}`);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setSelectedDate(null);
         return;
       }
 
@@ -250,7 +267,16 @@ export function CalendarView({
         return;
       }
     },
-    [viewMode, prevWeek, nextWeek, prevMonth, nextMonth, goToday],
+    [
+      moveSelection,
+      selectedDate,
+      router,
+      prevWeek,
+      nextWeek,
+      prevMonth,
+      nextMonth,
+      goToday,
+    ],
   );
 
   useEffect(() => {
@@ -343,7 +369,7 @@ export function CalendarView({
           onTaskClick={setSelectedTask}
           dayNames={DAY_NAMES}
           categoryColors={categoryColors}
-          selectedDayIdx={selectedDayIdx}
+          selectedDate={selectedDate}
         />
       ) : (
         <MonthView
@@ -354,6 +380,7 @@ export function CalendarView({
           onTaskClick={setSelectedTask}
           dayNames={DAY_NAMES}
           categoryColors={categoryColors}
+          selectedDate={selectedDate}
         />
       )}
 
@@ -381,7 +408,7 @@ function WeekView({
   onTaskClick,
   dayNames,
   categoryColors,
-  selectedDayIdx,
+  selectedDate,
 }: {
   weekStart: Date;
   today: Date;
@@ -390,7 +417,7 @@ function WeekView({
   onTaskClick: (task: Task) => void;
   dayNames: string[];
   categoryColors: Record<string, string>;
-  selectedDayIdx: number;
+  selectedDate: Date | null;
 }) {
   const days = useMemo(() => {
     const result: Date[] = [];
@@ -405,11 +432,12 @@ function WeekView({
       <div className="grid grid-cols-7 border-b border-border/60 shrink-0">
         {days.map((date, idx) => {
           const isToday = isSameDay(date, today);
-          const isSelected = idx === selectedDayIdx;
+          const isSelected =
+            selectedDate !== null && isSameDay(date, selectedDate);
           return (
             <div
               key={formatDateKey(date)}
-              className={`flex flex-col items-center py-2 ${isSelected ? "bg-accent" : isToday ? "bg-primary/5" : ""}`}
+              className={`flex flex-col items-center py-2 ${isSelected ? "bg-accent" : ""} ${isToday ? "ring-1 ring-primary/50" : ""}`}
             >
               <span className="text-xs text-muted-foreground">
                 {dayNames[idx]}
@@ -426,19 +454,20 @@ function WeekView({
         })}
       </div>
       <div className="grid grid-cols-7 flex-1 overflow-auto">
-        {days.map((date, idx) => {
+        {days.map((date) => {
           const key = formatDateKey(date);
           const dayTasks = tasksByDate.get(key) ?? [];
           const isToday = isSameDay(date, today);
-          const isSelected = idx === selectedDayIdx;
+          const isSelected =
+            selectedDate !== null && isSameDay(date, selectedDate);
 
           const blend = dayBlendStyle(dayTasks, categoryColors);
           return (
             <div
               key={key}
               className={`flex flex-col p-2 border-r border-border/30 ${
-                isSelected ? "bg-accent" : isToday ? "bg-primary/5" : ""
-              }`}
+                isSelected ? "bg-accent" : ""
+              } ${isToday ? "ring-1 ring-inset ring-primary/50" : ""}`}
               style={!isToday ? blend : undefined}
             >
               <div className="flex flex-col gap-1 w-full">
@@ -477,6 +506,7 @@ function MonthView({
   onTaskClick,
   dayNames,
   categoryColors,
+  selectedDate,
 }: {
   monthStart: Date;
   today: Date;
@@ -485,6 +515,7 @@ function MonthView({
   onTaskClick: (task: Task) => void;
   dayNames: string[];
   categoryColors: Record<string, string>;
+  selectedDate: Date | null;
 }) {
   const totalDays = daysInMonth(monthStart);
   const offset = weekOffset(monthStart);
@@ -531,6 +562,8 @@ function MonthView({
           const dateKey = formatDateKey(cellDate);
           const dayTasks = tasksByDate.get(dateKey) ?? [];
           const isToday = isSameDay(cellDate, today);
+          const isSelected =
+            selectedDate !== null && isSameDay(cellDate, selectedDate);
           const isPast = cellDate < today && !isToday;
           const blend = dayBlendStyle(dayTasks, categoryColors);
 
@@ -538,8 +571,8 @@ function MonthView({
             <div
               key={cell.key}
               className={`flex flex-col p-1.5 text-left transition-colors border-b border-r border-border/30 ${
-                isPast ? "opacity-50" : ""
-              }`}
+                isSelected ? "bg-accent" : ""
+              } ${isToday ? "ring-1 ring-inset ring-primary/50" : ""} ${isPast ? "opacity-50" : ""}`}
               style={blend}
             >
               <span

--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -139,6 +139,19 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
           }
           break;
         }
+        case "1":
+        case "2":
+        case "3":
+        case "4": {
+          e.preventDefault();
+          const ci = Number(e.key) - 1;
+          if (ci < columns.length) {
+            setKbActive(true);
+            setColIdx(ci);
+            setRowIdx(0);
+          }
+          break;
+        }
         case "Escape": {
           setKbActive(false);
           setColIdx(0);
@@ -193,9 +206,14 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
             }}
           >
             <div className="flex items-center justify-between px-3 py-2.5 border-b border-border/60">
-              <span className="text-xs font-medium">{col.label}</span>
-              <span className="text-xs text-muted-foreground tabular-nums">
-                {colTasks.length}
+              <span className="text-xs font-medium">
+                {col.label}
+                <span className="text-muted-foreground/40 ml-1.5">
+                  {colTasks.length}
+                </span>
+              </span>
+              <span className="text-[10px] text-muted-foreground/40 font-mono tabular-nums">
+                {ci + 1}
               </span>
             </div>
             <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION
## Problem

Calendar had limited keyboard navigation (h/l in week view only). Kanban column headers showed raw task counts that looked like shortcut numbers.

## Solution

Unified hjkl across both calendar views (±1 day / ±7 days), Enter navigates to queue filtered by date, today ring restored. Kanban gets 1-4 column jump shortcuts with hints in headers.