### PR TITLE
feat(ui): urgency row colors, kanban visual mode, category +

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -5,12 +5,14 @@ import {
   Columns3,
   type LucideIcon,
   Palette,
+  Plus,
   Zap,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { CategoryColorPicker } from "@/components/category-color-picker";
+import { CreateTaskDialog } from "@/components/create-task-dialog";
 import {
   Sidebar,
   SidebarContent,
@@ -41,6 +43,7 @@ export function AppSidebar({
   const searchParams = useSearchParams();
   const activeCategory = searchParams.get("category");
   const [editingColor, setEditingColor] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
 
   return (
     <Sidebar>
@@ -76,7 +79,16 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>
-          <SidebarGroupLabel>Categories</SidebarGroupLabel>
+          <SidebarGroupLabel className="flex items-center justify-between">
+            <span>Categories</span>
+            <button
+              type="button"
+              className="p-0.5 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setCreateOpen(true)}
+            >
+              <Plus className="size-3.5" />
+            </button>
+          </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {categories.map((cat, idx) => {
@@ -136,6 +148,11 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+      <CreateTaskDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        categories={categories}
+      />
     </Sidebar>
   );
 }

--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { Inbox } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { completeTaskAction, updateTaskAction } from "@/app/actions/tasks";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  completeTaskAction,
+  deleteTaskAction,
+  updateTaskAction,
+} from "@/app/actions/tasks";
 
 import { TaskDetail } from "@/components/task-detail";
 import type { Task, TaskStatus } from "@/core/types";
@@ -14,6 +18,16 @@ const defaultColumns: { status: TaskStatus; label: string }[] = [
   { status: "blocked", label: "Blocked" },
   { status: "done", label: "Done" },
 ];
+
+function rangeSet(tasks: Task[], a: number, b: number): Set<number> {
+  const lo = Math.min(a, b);
+  const hi = Math.max(a, b);
+  const ids = new Set<number>();
+  for (let i = lo; i <= hi; i++) {
+    if (i >= 0 && i < tasks.length) ids.add(tasks[i].id);
+  }
+  return ids;
+}
 
 function groupByStatus(tasks: Task[]): Record<string, Task[]> {
   const grouped: Record<string, Task[]> = {};
@@ -33,12 +47,21 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
   const [rowIdx, setRowIdx] = useState(0);
   const [kbActive, setKbActive] = useState(false);
   const [columns, setColumns] = useState(defaultColumns);
+  const [visualMode, setVisualMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const visualAnchor = useRef(-1);
   const grouped = groupByStatus(tasks);
 
   const getColTasks = useCallback(
     (ci: number) => grouped[columns[ci].status] ?? [],
     [grouped, columns],
   );
+
+  useEffect(() => {
+    if (!visualMode) return;
+    const colTasks = getColTasks(colIdx);
+    setSelectedIds(rangeSet(colTasks, visualAnchor.current, rowIdx));
+  }, [rowIdx, colIdx, visualMode, getColTasks]);
 
   const handler = useCallback(
     (e: KeyboardEvent) => {
@@ -48,6 +71,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
       switch (e.key) {
         case "h": {
           e.preventDefault();
+          if (visualMode) break;
           setKbActive(true);
           setColIdx((c) => Math.max(c - 1, 0));
           setRowIdx(0);
@@ -55,6 +79,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
         }
         case "l": {
           e.preventDefault();
+          if (visualMode) break;
           setKbActive(true);
           setColIdx((c) => Math.min(c + 1, columns.length - 1));
           setRowIdx(0);
@@ -77,6 +102,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
         }
         case "H": {
           e.preventDefault();
+          if (visualMode) break;
           const colTasksH = getColTasks(colIdx);
           if (colTasksH.length === 0 || rowIdx >= colTasksH.length) break;
           const taskH = colTasksH[rowIdx];
@@ -94,6 +120,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
         }
         case "L": {
           e.preventDefault();
+          if (visualMode) break;
           const colTasksL = getColTasks(colIdx);
           if (colTasksL.length === 0 || rowIdx >= colTasksL.length) break;
           const taskL = colTasksL[rowIdx];
@@ -111,6 +138,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
         }
         case "<": {
           e.preventDefault();
+          if (visualMode) break;
           if (colIdx <= 0) break;
           setColumns((prev) => {
             const next = [...prev];
@@ -122,6 +150,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
         }
         case ">": {
           e.preventDefault();
+          if (visualMode) break;
           if (colIdx >= columns.length - 1) break;
           setColumns((prev) => {
             const next = [...prev];
@@ -152,15 +181,72 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
           }
           break;
         }
+        case "V": {
+          e.preventDefault();
+          if (visualMode) {
+            setVisualMode(false);
+            setSelectedIds(new Set());
+          } else if (kbActive) {
+            const colTasks = getColTasks(colIdx);
+            if (colTasks.length > 0 && rowIdx < colTasks.length) {
+              setVisualMode(true);
+              visualAnchor.current = rowIdx;
+              setSelectedIds(new Set([colTasks[rowIdx].id]));
+            }
+          }
+          break;
+        }
+        case "x": {
+          e.preventDefault();
+          if (selectedIds.size > 0) {
+            for (const id of selectedIds) completeTaskAction(id);
+            setSelectedIds(new Set());
+            setVisualMode(false);
+          } else if (kbActive) {
+            const colTasks = getColTasks(colIdx);
+            if (colTasks.length > 0 && rowIdx < colTasks.length) {
+              completeTaskAction(colTasks[rowIdx].id);
+            }
+          }
+          break;
+        }
+        case "d": {
+          e.preventDefault();
+          if (selectedIds.size > 0) {
+            for (const id of selectedIds) deleteTaskAction(id);
+            setSelectedIds(new Set());
+            setVisualMode(false);
+          } else if (kbActive) {
+            const colTasks = getColTasks(colIdx);
+            if (colTasks.length > 0 && rowIdx < colTasks.length) {
+              deleteTaskAction(colTasks[rowIdx].id);
+            }
+          }
+          break;
+        }
         case "Escape": {
-          setKbActive(false);
-          setColIdx(0);
-          setRowIdx(0);
+          if (visualMode) {
+            setVisualMode(false);
+            setSelectedIds(new Set());
+          } else {
+            setKbActive(false);
+            setColIdx(0);
+            setRowIdx(0);
+          }
           break;
         }
       }
     },
-    [colIdx, rowIdx, getColTasks, selectedTask, columns],
+    [
+      colIdx,
+      rowIdx,
+      getColTasks,
+      selectedTask,
+      columns,
+      kbActive,
+      visualMode,
+      selectedIds,
+    ],
   );
 
   useEffect(() => {
@@ -225,6 +311,10 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
               ) : (
                 colTasks.map((task, ri) => {
                   const isCursor = isActiveCol && ri === rowIdx;
+                  const isSelected = selectedIds.has(task.id);
+                  let bg = "hover:bg-accent/50";
+                  if (isSelected) bg = "bg-primary/10";
+                  else if (isCursor) bg = "bg-accent";
                   return (
                     <article
                       key={task.id}
@@ -237,9 +327,9 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
                         setDragId(null);
                         setDragOver(null);
                       }}
-                      className={`border-b border-border/40 p-3 cursor-grab active:cursor-grabbing transition-colors hover:bg-accent/50 ${
+                      className={`border-b border-border/40 p-3 cursor-grab active:cursor-grabbing transition-colors ${bg} ${
                         dragId === task.id ? "opacity-40" : ""
-                      } ${isCursor ? "bg-accent" : ""}`}
+                      }`}
                     >
                       <button
                         type="button"

--- a/src/components/queue-view.tsx
+++ b/src/components/queue-view.tsx
@@ -48,21 +48,19 @@ export function QueueView({
   const [createOpen, setCreateOpen] = useState(false);
   const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
-  const { cursor, setCursor, selectedIds, toggleSelect, visualMode } =
-    useKeyboard({
-      tasks,
-      onComplete: (ids) => {
-        for (const id of ids) completeTaskAction(id);
-      },
-      onDelete: (ids) => {
-        for (const id of ids) deleteTaskAction(id);
-        if (selectedTask && ids.includes(selectedTask.id))
-          setSelectedTask(null);
-      },
-      onCreate: () => setCreateOpen(true),
-      onSelect: (task) => setSelectedTask(task as RankedTask),
-      onDeselect: () => setSelectedTask(null),
-    });
+  const { cursor, setCursor, selectedIds, toggleSelect } = useKeyboard({
+    tasks,
+    onComplete: (ids) => {
+      for (const id of ids) completeTaskAction(id);
+    },
+    onDelete: (ids) => {
+      for (const id of ids) deleteTaskAction(id);
+      if (selectedTask && ids.includes(selectedTask.id)) setSelectedTask(null);
+    },
+    onCreate: () => setCreateOpen(true),
+    onSelect: (task) => setSelectedTask(task as RankedTask),
+    onDeselect: () => setSelectedTask(null),
+  });
 
   useEffect(() => {
     if (cursor >= 0 && cursor < tasks.length) {
@@ -91,22 +89,6 @@ export function QueueView({
 
   return (
     <div className="flex flex-col h-full">
-      {visualMode && (
-        <div className="flex items-center gap-2 px-6 py-1.5 bg-primary/10 text-xs text-primary border-b border-primary/20">
-          <span className="font-medium">VISUAL</span>
-          <span className="text-primary/70">
-            {selectedIds.size} selected — x complete, d delete, Esc cancel
-          </span>
-        </div>
-      )}
-      {!visualMode && selectedIds.size > 0 && (
-        <div className="flex items-center gap-2 px-6 py-1.5 bg-primary/10 text-xs text-primary border-b border-primary/20">
-          <span className="font-medium">{selectedIds.size} selected</span>
-          <span className="text-primary/70">
-            x complete, d delete, Esc clear
-          </span>
-        </div>
-      )}
       <div className="flex-1 overflow-auto">
         {tasks.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground py-16">
@@ -119,7 +101,7 @@ export function QueueView({
               const isCursor = i === cursor;
               const isSelected = selectedIds.has(task.id);
 
-              let bg = "hover:bg-accent/50";
+              let bg = `${urgencyBg(task.urgency)} hover:bg-accent/50`;
               if (isSelected) bg = "bg-primary/10";
               else if (isCursor) bg = "bg-accent";
 


### PR DESCRIPTION
## Problem

Queue rows only colored the small urgency badge. Kanban had no visual/multi-select mode. No quick way to create tasks from sidebar.

## Solution

- Color entire queue rows by urgency (`bg-status-blocked/10`, `bg-status-wip/10`), remove VISUAL banner
- Add V/x/d visual mode to kanban (matching queue behavior)
- Add `+` button next to Categories header in sidebar to open create dialog