### PR TITLE
fix(ui): sidebar collapsed, borderless editor, spacing tweaks

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -79,7 +79,7 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>
-          <div className="flex h-8 shrink-0 items-center justify-between px-2">
+          <div className="flex h-8 shrink-0 items-center justify-between px-2 pr-3">
             <span className="text-xs font-medium text-sidebar-foreground/70">
               Categories
             </span>

--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -292,12 +292,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
             }}
           >
             <div className="flex items-center justify-between px-3 py-2.5 border-b border-border/60">
-              <span className="text-xs font-medium">
-                {col.label}
-                <span className="text-muted-foreground/40 ml-1.5">
-                  {colTasks.length}
-                </span>
-              </span>
+              <span className="text-xs font-medium">{col.label}</span>
               <span className="text-[10px] text-muted-foreground/40 font-mono tabular-nums">
                 {ci + 1}
               </span>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -7,7 +7,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <SidebarProvider>{children}</SidebarProvider>
+      <SidebarProvider defaultOpen={false}>{children}</SidebarProvider>
       <Toaster
         theme="system"
         position="bottom-right"

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -145,7 +145,7 @@ export function TaskDetail({
           className="fixed inset-4 sm:inset-8 z-50 mx-auto max-w-3xl flex flex-col border border-border bg-card duration-150 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-[0.97] data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-[0.97]"
           onKeyDown={handleKeyDown}
         >
-          <div className="px-6 pt-6 pb-3">
+          <div className="px-6 pt-4 pb-2">
             <input
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -154,7 +154,7 @@ export function TaskDetail({
             />
           </div>
 
-          <div className="flex flex-wrap items-center gap-3 px-6 pb-3 border-b border-border/40">
+          <div className="flex flex-wrap items-center gap-3 px-6 pb-2 border-b border-border/40">
             <Select
               value={task.status}
               onValueChange={(v) => v && handleStatusChange(v)}
@@ -235,7 +235,7 @@ export function TaskDetail({
             )}
           </div>
 
-          <div className="flex-1 min-h-0 overflow-auto p-6">
+          <div className="flex-1 min-h-0 overflow-auto px-6 pt-3 pb-6">
             <TiptapEditor
               content={task.notes ?? null}
               onChange={(json) => {

--- a/src/components/tiptap-editor.tsx
+++ b/src/components/tiptap-editor.tsx
@@ -140,8 +140,8 @@ export function TiptapEditor({
   if (!editor) return null;
 
   return (
-    <div className="border border-input bg-transparent transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/50">
-      <div className="flex flex-wrap gap-0.5 border-b border-input px-1 py-1">
+    <div className="bg-transparent">
+      <div className="flex flex-wrap gap-0.5 border-b border-border/40 px-1 py-1">
         <Button
           type="button"
           variant="ghost"


### PR DESCRIPTION
## Problem

Sidebar defaulted open, tiptap double-bordered, detail view spacing too loose, kanban counts confusing.

## Solution

`defaultOpen={false}` on sidebar. Borderless tiptap. Tighter detail padding (`pt-4 pb-2`). Remove kanban column counts. Align sidebar `+` with `pr-3`.