### PR TITLE
feat(ui): # prefix on categories everywhere

### DIFF
--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -342,7 +342,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
                           )}
                           {task.category && task.category !== "Todo" && (
                             <span className="text-xs text-muted-foreground">
-                              {task.category}
+                              #{task.category}
                             </span>
                           )}
                           {task.due && (

--- a/src/components/queue-view.tsx
+++ b/src/components/queue-view.tsx
@@ -50,12 +50,14 @@ function InlineEdit({
   className,
   type = "text",
   suggestions,
+  prefix,
 }: {
   value: string;
   onSave: (v: string) => void;
   className?: string;
   type?: "text" | "date";
   suggestions?: string[];
+  prefix?: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -86,7 +88,9 @@ function InlineEdit({
       >
         {type === "date" && value
           ? formatDate(new Date(value))
-          : value || "\u00a0"}
+          : value
+            ? `${prefix ?? ""}${value}`
+            : "\u00a0"}
       </button>
     );
   }
@@ -245,6 +249,7 @@ export function QueueView({
                       updateTaskAction(task.id, { category: v || null })
                     }
                     suggestions={categories}
+                    prefix="#"
                     className="w-24 truncate text-xs text-muted-foreground text-right shrink-0"
                   />
                   <InlineEdit


### PR DESCRIPTION
## Problem

Categories hard to distinguish from other text.

## Solution

Prefix with `#` in queue (inline edit display) and kanban (card text). Sidebar already had it.