### PR TITLE
fix(ui): kanban visual mode loop, faster sidebar

### DIFF
--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Inbox } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   completeTaskAction,
   deleteTaskAction,
@@ -50,7 +50,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
   const [visualMode, setVisualMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const visualAnchor = useRef(-1);
-  const grouped = groupByStatus(tasks);
+  const grouped = useMemo(() => groupByStatus(tasks), [tasks]);
 
   const getColTasks = useCallback(
     (ci: number) => grouped[columns[ci].status] ?? [],
@@ -59,9 +59,9 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
 
   useEffect(() => {
     if (!visualMode) return;
-    const colTasks = getColTasks(colIdx);
+    const colTasks = grouped[columns[colIdx].status] ?? [];
     setSelectedIds(rangeSet(colTasks, visualAnchor.current, rowIdx));
-  }, [rowIdx, colIdx, visualMode, getColTasks]);
+  }, [rowIdx, colIdx, visualMode, grouped, columns]);
 
   const handler = useCallback(
     (e: KeyboardEvent) => {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -217,7 +217,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-100 ease-linear",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -229,7 +229,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-100 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
@@ -399,7 +399,7 @@ function SidebarGroupLabel({
     props: mergeProps<"div">(
       {
         className: cn(
-          "flex h-8 shrink-0 items-center px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          "flex h-8 shrink-0 items-center px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-100 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
           className,
         ),
       },


### PR DESCRIPTION
## Problem

Kanban visual mode caused infinite re-render loop. Sidebar transition too slow.

## Solution

Memoize `grouped` to stabilize `getColTasks` identity. Reduce sidebar duration to 100ms.