### PR TITLE
feat(ui): g? keymap help, persistent category input

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -5,7 +5,6 @@ import {
   Columns3,
   type LucideIcon,
   Palette,
-  Plus,
   Zap,
 } from "lucide-react";
 import Link from "next/link";
@@ -13,7 +12,6 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useRef, useState } from "react";
 import { createTaskAction } from "@/app/actions/tasks";
 import { CategoryColorPicker } from "@/components/category-color-picker";
-import { Input } from "@/components/ui/input";
 import {
   Sidebar,
   SidebarContent,
@@ -44,7 +42,6 @@ export function AppSidebar({
   const searchParams = useSearchParams();
   const activeCategory = searchParams.get("category");
   const [editingColor, setEditingColor] = useState<string | null>(null);
-  const [adding, setAdding] = useState(false);
   const [newCat, setNewCat] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -54,7 +51,6 @@ export function AppSidebar({
       createTaskAction({ description: `New ${name} task`, category: name });
     }
     setNewCat("");
-    setAdding(false);
   }
 
   return (
@@ -91,21 +87,7 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>
-          <div className="flex h-8 shrink-0 items-center justify-between px-2">
-            <span className="text-xs font-medium text-sidebar-foreground/70">
-              Categories
-            </span>
-            <button
-              type="button"
-              className="p-0.5 text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() => {
-                setAdding(true);
-                requestAnimationFrame(() => inputRef.current?.focus());
-              }}
-            >
-              <Plus className="size-3.5" />
-            </button>
-          </div>
+          <SidebarGroupLabel>Categories</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {categories.map((cat, idx) => {
@@ -161,26 +143,23 @@ export function AppSidebar({
                   </SidebarMenuItem>
                 );
               })}
-              {adding && (
-                <SidebarMenuItem>
-                  <Input
-                    ref={inputRef}
-                    value={newCat}
-                    onChange={(e) => setNewCat(e.target.value)}
-                    onBlur={handleAdd}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleAdd();
-                      if (e.key === "Escape") {
-                        setNewCat("");
-                        setAdding(false);
-                      }
-                      e.stopPropagation();
-                    }}
-                    placeholder="category name"
-                    className="h-8 text-sm mx-2 w-auto"
-                  />
-                </SidebarMenuItem>
-              )}
+              <SidebarMenuItem>
+                <input
+                  ref={inputRef}
+                  value={newCat}
+                  onChange={(e) => setNewCat(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAdd();
+                    if (e.key === "Escape") {
+                      setNewCat("");
+                      inputRef.current?.blur();
+                    }
+                    e.stopPropagation();
+                  }}
+                  placeholder="new category..."
+                  className="w-full h-8 px-2 text-sm bg-transparent text-muted-foreground placeholder:text-muted-foreground/40 outline-none"
+                />
+              </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/src/components/global-keyboard.tsx
+++ b/src/components/global-keyboard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { KeymapHelp } from "@/components/keymap-help";
 import { useSidebar } from "@/components/ui/sidebar";
 import { isInputFocused } from "@/lib/utils";
 
@@ -15,10 +16,42 @@ const CATEGORY_KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 export function GlobalKeyboard({ categories = [] }: { categories?: string[] }) {
   const router = useRouter();
   const { toggleSidebar } = useSidebar();
+  const [helpOpen, setHelpOpen] = useState(false);
+  const pendingG = useRef(false);
+  const gTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handler = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
+
+      if (pendingG.current && e.key === "?") {
+        e.preventDefault();
+        pendingG.current = false;
+        if (gTimer.current) {
+          clearTimeout(gTimer.current);
+          gTimer.current = null;
+        }
+        setHelpOpen(true);
+        return;
+      }
+
+      if (e.key === "g" && !e.shiftKey) {
+        pendingG.current = true;
+        if (gTimer.current) clearTimeout(gTimer.current);
+        gTimer.current = setTimeout(() => {
+          pendingG.current = false;
+          gTimer.current = null;
+        }, 500);
+        return;
+      }
+
+      if (pendingG.current) {
+        pendingG.current = false;
+        if (gTimer.current) {
+          clearTimeout(gTimer.current);
+          gTimer.current = null;
+        }
+      }
 
       if (e.key === "-" && !document.querySelector("[role=dialog]")) {
         e.preventDefault();
@@ -55,5 +88,11 @@ export function GlobalKeyboard({ categories = [] }: { categories?: string[] }) {
     return () => window.removeEventListener("keydown", handler);
   }, [handler]);
 
-  return null;
+  useEffect(() => {
+    return () => {
+      if (gTimer.current) clearTimeout(gTimer.current);
+    };
+  }, []);
+
+  return <KeymapHelp open={helpOpen} onClose={() => setHelpOpen(false)} />;
 }

--- a/src/components/keymap-help.tsx
+++ b/src/components/keymap-help.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+
+const sections = [
+  {
+    title: "Global",
+    keys: [
+      ["Q", "Queue view"],
+      ["K", "Kanban view"],
+      ["C", "Calendar view"],
+      ["-", "Toggle sidebar"],
+      ["q", "Logout"],
+      ["1-9", "Jump to category"],
+      ["g?", "This help"],
+    ],
+  },
+  {
+    title: "Queue",
+    keys: [
+      ["j / k", "Move down / up"],
+      ["gg", "Jump to top"],
+      ["G", "Jump to bottom"],
+      ["Enter", "Open task detail"],
+      ["o", "Create task"],
+      ["x", "Complete task"],
+      ["d", "Delete task"],
+      ["V", "Visual select mode"],
+      ["Escape", "Clear selection / close"],
+    ],
+  },
+  {
+    title: "Kanban",
+    keys: [
+      ["h / l", "Move between columns"],
+      ["j / k", "Move within column"],
+      ["H / L", "Move task left / right"],
+      ["< / >", "Swap column left / right"],
+      ["1-4", "Jump to column"],
+      ["Enter", "Open task detail"],
+      ["V", "Visual select mode"],
+      ["x", "Complete task"],
+      ["d", "Delete task"],
+      ["Escape", "Deactivate keyboard"],
+    ],
+  },
+  {
+    title: "Calendar",
+    keys: [
+      ["h / l", "Previous / next day"],
+      ["j / k", "Previous / next week"],
+      ["Enter", "View day in queue"],
+      ["w", "Week view"],
+      ["m", "Month view"],
+      ["[m / ]m", "Previous / next month"],
+      ["t", "Jump to today"],
+      ["Escape", "Clear selection"],
+    ],
+  },
+  {
+    title: "Task Detail",
+    keys: [
+      ["j / k", "Next / previous task"],
+      ["Ctrl+S", "Save"],
+      ["Escape", "Close"],
+    ],
+  },
+];
+
+export function KeymapHelp({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/60 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Popup className="fixed inset-8 z-50 mx-auto max-w-2xl flex flex-col border border-border bg-card duration-100 outline-none overflow-auto data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-border/40">
+            <span className="text-sm font-medium">Keyboard Shortcuts</span>
+            <kbd className="text-[10px] text-muted-foreground">
+              Escape to close
+            </kbd>
+          </div>
+          <div className="grid grid-cols-2 gap-6 p-6 overflow-auto">
+            {sections.map((section) => (
+              <div key={section.title}>
+                <h3 className="text-xs font-medium text-muted-foreground mb-3">
+                  {section.title}
+                </h3>
+                <div className="flex flex-col gap-1.5">
+                  {section.keys.map(([key, desc]) => (
+                    <div
+                      key={key}
+                      className="flex items-center justify-between gap-4"
+                    >
+                      <kbd className="text-xs text-foreground shrink-0 min-w-16">
+                        {key}
+                      </kbd>
+                      <span className="text-xs text-muted-foreground text-right">
+                        {desc}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}


### PR DESCRIPTION
## Problem

No way to discover keyboard shortcuts. Category creation required a click-to-reveal flow.

## Solution

- `g?` opens a help panel with all shortcuts organized by view
- Persistent borderless input at the bottom of category list — type and Enter to create