### PR TITLE
fix(ui): kanban column keys p/i/b/w instead of 1-4

### DIFF
--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -12,6 +12,9 @@ import { Input } from "@/components/ui/input";
 import type { Task, TaskStatus } from "@/core/types";
 import { formatDate, isInputFocused } from "@/lib/utils";
 
+const COLUMN_KEYS = ["p", "i", "b", "w"];
+const COLUMN_HINTS = ["P", "I", "B", "W"];
+
 const defaultColumns: { status: TaskStatus; label: string }[] = [
   { status: "pending", label: "Pending" },
   { status: "wip", label: "In Progress" },
@@ -208,13 +211,13 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
           }
           break;
         }
-        case "1":
-        case "2":
-        case "3":
-        case "4": {
+        case "p":
+        case "i":
+        case "b":
+        case "w": {
           e.preventDefault();
-          const ci = Number(e.key) - 1;
-          if (ci < columns.length) {
+          const ci = COLUMN_KEYS.indexOf(e.key);
+          if (ci !== -1 && ci < columns.length) {
             setKbActive(true);
             setColIdx(ci);
             setRowIdx(0);
@@ -384,7 +387,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
               <div className="flex items-center justify-between px-3 py-2.5 border-b border-border/60">
                 <span className="text-xs font-medium">{col.label}</span>
                 <span className="text-[10px] text-muted-foreground/40 font-mono tabular-nums">
-                  {ci + 1}
+                  {COLUMN_HINTS[ci]}
                 </span>
               </div>
               <div className="flex-1 overflow-y-auto">

--- a/src/components/keymap-help.tsx
+++ b/src/components/keymap-help.tsx
@@ -40,7 +40,7 @@ const sections = [
       ["j / k", "Move within column"],
       ["H / L", "Move task left / right"],
       ["< / >", "Swap column left / right"],
-      ["1-4", "Jump to column"],
+      ["p / i / b / w", "Jump to column"],
       ["/", "Search filter"],
       ["Enter", "Open task detail"],
       ["V", "Visual select mode"],


### PR DESCRIPTION
## Problem

Kanban column shortcuts `1-4` conflicted with global `1-9` category jump keybindings.

## Solution

Change column jump keys to `p`/`i`/`b`/`w` (Pending, In progress, Blocked, Won). Update column hint labels and keymap help panel.