### PR TITLE
fix(ui): remove delete confirmation prompt

### DIFF
--- a/src/components/queue-view.tsx
+++ b/src/components/queue-view.tsx
@@ -64,25 +64,23 @@ export function QueueView({ tasks }: { tasks: RankedTask[] }) {
 
   const gutterWidth = String(filtered.length).length;
 
-  const { cursor, setCursor, selectedIds, toggleSelect, pendingDelete } =
-    useKeyboard({
-      tasks: filtered,
-      onComplete: (ids) => {
-        for (const id of ids) completeTaskAction(id);
-      },
-      onDelete: (ids) => {
-        for (const id of ids) deleteTaskAction(id);
-        if (selectedTask && ids.includes(selectedTask.id))
-          setSelectedTask(null);
-      },
-      onStatusChange: (ids, status) => {
-        for (const id of ids) updateTaskAction(id, { status });
-      },
-      onSelect: (task) => setSelectedTask(task as RankedTask),
-      onDeselect: () => setSelectedTask(null),
-      onHelp: () => window.dispatchEvent(new Event("open-keymap-help")),
-      scrollRef,
-    });
+  const { cursor, setCursor, selectedIds, toggleSelect } = useKeyboard({
+    tasks: filtered,
+    onComplete: (ids) => {
+      for (const id of ids) completeTaskAction(id);
+    },
+    onDelete: (ids) => {
+      for (const id of ids) deleteTaskAction(id);
+      if (selectedTask && ids.includes(selectedTask.id)) setSelectedTask(null);
+    },
+    onStatusChange: (ids, status) => {
+      for (const id of ids) updateTaskAction(id, { status });
+    },
+    onSelect: (task) => setSelectedTask(task as RankedTask),
+    onDeselect: () => setSelectedTask(null),
+    onHelp: () => window.dispatchEvent(new Event("open-keymap-help")),
+    scrollRef,
+  });
 
   const openSearch = useCallback(() => {
     setSearchActive(true);
@@ -154,14 +152,6 @@ export function QueueView({ tasks }: { tasks: RankedTask[] }) {
           />
           <span className="text-[10px] text-muted-foreground shrink-0">
             {filtered.length}/{tasks.length}
-          </span>
-        </div>
-      )}
-      {pendingDelete && (
-        <div className="flex items-center gap-2 px-6 py-1.5 bg-destructive/10 text-xs text-destructive border-b border-destructive/20">
-          <span>
-            delete {pendingDelete.length} task
-            {pendingDelete.length > 1 ? "s" : ""}? y/N
           </span>
         </div>
       )}

--- a/src/hooks/use-keyboard.ts
+++ b/src/hooks/use-keyboard.ts
@@ -45,7 +45,6 @@ export function useKeyboard(actions: KeyboardActions) {
   const [cursor, setCursor] = useState(-1);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [visualMode, setVisualMode] = useState(false);
-  const [pendingDelete, setPendingDelete] = useState<number[] | null>(null);
   const visualAnchor = useRef(-1);
   const countBuf = useRef("");
   const pendingG = useRef<number | null | false>(false);
@@ -78,7 +77,7 @@ export function useKeyboard(actions: KeyboardActions) {
   const applyOp = useCallback((op: string, ids: number[]) => {
     if (ids.length === 0) return;
     if (op === "d") {
-      setPendingDelete(ids);
+      actionsRef.current.onDelete(ids);
     } else {
       const status = STATUS_OPS[op];
       if (status) actionsRef.current.onStatusChange(ids, status);
@@ -97,17 +96,6 @@ export function useKeyboard(actions: KeyboardActions) {
   const handler = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
-
-      if (pendingDelete) {
-        e.preventDefault();
-        if (e.key === "y") {
-          actionsRef.current.onDelete(pendingDelete);
-          setSelectedIds(new Set());
-          setVisualMode(false);
-        }
-        setPendingDelete(null);
-        return;
-      }
 
       const { tasks, onComplete, onSelect, onDeselect } = actionsRef.current;
       const isModifier = ["Shift", "Control", "Alt", "Meta"].includes(e.key);
@@ -292,15 +280,7 @@ export function useKeyboard(actions: KeyboardActions) {
         }
       }
     },
-    [
-      cursor,
-      selectedIds,
-      visualMode,
-      pendingDelete,
-      toggleSelect,
-      applyOp,
-      consumeCount,
-    ],
+    [cursor, selectedIds, visualMode, toggleSelect, applyOp, consumeCount],
   );
 
   useEffect(() => {
@@ -321,6 +301,5 @@ export function useKeyboard(actions: KeyboardActions) {
     selectedIds,
     toggleSelect,
     visualMode,
-    pendingDelete,
   };
 }


### PR DESCRIPTION
## Problem

The y/N confirmation on `dd` added friction to what should be an instant vim-style action.

## Solution

Remove `pendingDelete` state and y/N confirmation banner. `dd` now calls `onDelete` directly. Undo system tracked in #93.