### PR TITLE
fix(core): don't block task when dependency is already resolved

### DIFF
--- a/src/core/dag.ts
+++ b/src/core/dag.ts
@@ -24,10 +24,19 @@ export function addDependency(
     .get();
 
   if (task?.status === "pending") {
-    db.update(tasks)
-      .set({ status: "blocked", updatedAt: new Date().toISOString() })
-      .where(eq(tasks.id, taskId))
-      .run();
+    const depTask = db
+      .select({ status: tasks.status })
+      .from(tasks)
+      .where(eq(tasks.id, dependsOnId))
+      .get();
+    const resolved =
+      depTask?.status === "done" || depTask?.status === "cancelled";
+    if (!resolved) {
+      db.update(tasks)
+        .set({ status: "blocked", updatedAt: new Date().toISOString() })
+        .where(eq(tasks.id, taskId))
+        .run();
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`addDependency` blindly set dependent tasks to blocked even when the dependency target was already done/cancelled.

## Solution

Check dependency target status before blocking. Only transition to blocked if the target is unresolved.