### PR TITLE
feat(core): label field for sub-category tagging

### DIFF
--- a/drizzle/0006_wet_zzzax.sql
+++ b/drizzle/0006_wet_zzzax.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `label` text;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,569 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d89feec4-cf60-4bcf-98cf-406421b6f0c2",
+  "prevId": "374afd73-e044-4701-a86d-62d96a8074d2",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_provider_provider_account_id_unique": {
+          "name": "accounts_provider_provider_account_id_unique",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automations_user_id_users_id_fk": {
+          "name": "automations_user_id_users_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category_colors": {
+      "name": "category_colors",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_colors_user_id_users_id_fk": {
+          "name": "category_colors_user_id_users_id_fk",
+          "tableFrom": "category_colors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "category_colors_user_id_category_pk": {
+          "columns": [
+            "user_id",
+            "category"
+          ],
+          "name": "category_colors_user_id_category_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_dependencies": {
+      "name": "task_dependencies",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depends_on_id": {
+          "name": "depends_on_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_dependencies_task_id_tasks_id_fk": {
+          "name": "task_dependencies_task_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependencies_depends_on_id_tasks_id_fk": {
+          "name": "task_dependencies_depends_on_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "depends_on_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_dependencies_task_id_depends_on_id_pk": {
+          "columns": [
+            "task_id",
+            "depends_on_id"
+          ],
+          "name": "task_dependencies_task_id_depends_on_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Todo'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recur_mode": {
+          "name": "recur_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_api_key_unique": {
+          "name": "users_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1774237341309,
       "tag": "0005_aromatic_kylun",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1774465228477,
+      "tag": "0006_wet_zzzax",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -21,6 +21,7 @@ export default async function QueuePage({
 }: {
   searchParams: Promise<{
     category?: string;
+    label?: string;
     status?: string;
     date?: string;
     showDone?: string;
@@ -38,6 +39,7 @@ export default async function QueuePage({
     settings.defaultView !== "queue" &&
     settings.defaultView !== "list" &&
     !params.category &&
+    !params.label &&
     !params.status &&
     !params.date
   ) {
@@ -47,6 +49,7 @@ export default async function QueuePage({
   const filters: TaskFilters = {};
 
   if (params.category) filters.category = params.category;
+  if (params.label) filters.label = params.label;
   if (params.status) {
     filters.status = params.status.split(",") as TaskStatus[];
   }

--- a/src/components/create-task-drawer.tsx
+++ b/src/components/create-task-drawer.tsx
@@ -30,6 +30,7 @@ export function CreateTaskDrawer({
 }) {
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState(defaultCategory);
+  const [label, setLabel] = useState("");
   const [priority, setPriority] = useState("0");
   const [dueDate, setDueDate] = useState("");
   const [dueTime, setDueTime] = useState("");
@@ -57,6 +58,7 @@ export function CreateTaskDrawer({
     const result = await createTaskAction({
       description: description.trim(),
       category,
+      label: label.trim() || undefined,
       priority: Number(priority),
       due: dueDate
         ? new Date(`${dueDate}T${dueTime || "12:00"}:00`).toISOString()
@@ -70,6 +72,7 @@ export function CreateTaskDrawer({
 
     setDescription("");
     setCategory(defaultCategory);
+    setLabel("");
     setPriority("0");
     setDueDate("");
     setDueTime("");
@@ -100,7 +103,7 @@ export function CreateTaskDrawer({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What needs to be done?"
             />
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
               <div className="flex flex-col gap-1.5 relative">
                 <Label
                   htmlFor="drawer-category"
@@ -136,6 +139,20 @@ export function CreateTaskDrawer({
                     ))}
                   </div>
                 )}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label
+                  htmlFor="drawer-label"
+                  className="text-xs text-muted-foreground"
+                >
+                  Label
+                </Label>
+                <Input
+                  id="drawer-label"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  placeholder="e.g. RUTR 2730"
+                />
               </div>
               <div className="flex flex-col gap-1.5">
                 <Label className="text-xs text-muted-foreground">

--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -65,7 +65,8 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
     return tasks.filter(
       (t) =>
         t.description.toLowerCase().includes(q) ||
-        t.category?.toLowerCase().includes(q),
+        t.category?.toLowerCase().includes(q) ||
+        t.label?.toLowerCase().includes(q),
     );
   }, [tasks, searchQuery]);
 
@@ -476,6 +477,14 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
                               # {task.category}
                             </span>
                           )}
+                          {task.label?.split(",").map((l) => (
+                            <span
+                              key={l.trim()}
+                              className="text-xs text-muted-foreground"
+                            >
+                              [{l.trim()}]
+                            </span>
+                          ))}
                           {task.due && (
                             <span className="text-xs text-muted-foreground ml-auto tabular-nums">
                               {formatDate(new Date(task.due))}

--- a/src/components/queue-view.tsx
+++ b/src/components/queue-view.tsx
@@ -58,7 +58,8 @@ export function QueueView({ tasks }: { tasks: RankedTask[] }) {
     return tasks.filter(
       (t) =>
         t.description.toLowerCase().includes(q) ||
-        t.category?.toLowerCase().includes(q),
+        t.category?.toLowerCase().includes(q) ||
+        t.label?.toLowerCase().includes(q),
     );
   }, [tasks, searchQuery]);
 
@@ -211,6 +212,13 @@ export function QueueView({ tasks }: { tasks: RankedTask[] }) {
                   >
                     {task.description}
                   </span>
+                  {task.label && (
+                    <span className="text-xs text-muted-foreground shrink-0 flex gap-1">
+                      {task.label.split(",").map((l) => (
+                        <span key={l.trim()}>[{l.trim()}]</span>
+                      ))}
+                    </span>
+                  )}
                   {task.category && (
                     <span className="w-24 truncate text-xs text-muted-foreground text-right shrink-0">
                       # {task.category}

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -46,6 +46,7 @@ export function TaskDetail({
 }) {
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState("");
+  const [label, setLabel] = useState("");
   const [priority, setPriority] = useState("0");
   const [due, setDue] = useState("");
   const [showCategorySuggestions, setShowCategorySuggestions] = useState(false);
@@ -72,6 +73,7 @@ export function TaskDetail({
     if (task) {
       setDescription(task.description);
       setCategory(task.category ?? "");
+      setLabel(task.label ?? "");
       setPriority(String(task.priority ?? 0));
       setDue(task.due ? task.due.slice(0, 16) : "");
       notesRef.current = task.notes ?? null;
@@ -83,11 +85,12 @@ export function TaskDetail({
     await updateTaskAction(task.id, {
       description,
       category: category || null,
+      label: label || null,
       priority: Number(priority),
       due: due ? new Date(due).toISOString() : null,
       notes: notesRef.current || null,
     });
-  }, [task, description, category, priority, due]);
+  }, [task, description, category, label, priority, due]);
 
   const handleClose = useCallback(async () => {
     await handleSave();

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, like, lte } from "drizzle-orm";
 import { tasks } from "@/db/schema";
 import { updateBlockedStatus } from "./dag";
 import { getNextTaskData } from "./recurrence";
@@ -27,6 +27,7 @@ export function createTask(
       description: input.description,
       status: input.status ?? "pending",
       category: input.category ?? "Todo",
+      label: input.label ?? null,
       priority: input.priority ?? 0,
       due: input.due ?? null,
       recurrence: input.recurrence ?? null,
@@ -74,6 +75,10 @@ export function listTasks(
 
   if (filters?.category) {
     conditions.push(eq(tasks.category, filters.category));
+  }
+
+  if (filters?.label) {
+    conditions.push(like(tasks.label, `%${filters.label}%`));
   }
 
   if (filters?.dueBefore) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,6 +21,7 @@ export interface CreateTaskInput {
   description: string;
   status?: TaskStatus;
   category?: string;
+  label?: string;
   priority?: number;
   due?: string;
   recurrence?: string;
@@ -33,6 +34,7 @@ export interface UpdateTaskInput {
   description?: string;
   status?: TaskStatus;
   category?: string | null;
+  label?: string | null;
   priority?: number;
   due?: string | null;
   recurrence?: string | null;
@@ -44,6 +46,7 @@ export interface UpdateTaskInput {
 export interface TaskFilters {
   status?: TaskStatus | TaskStatus[];
   category?: string;
+  label?: string;
   dueBefore?: string;
   dueAfter?: string;
   minPriority?: number;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,6 +39,7 @@ export const tasks = sqliteTable("tasks", {
     .notNull()
     .default("pending"),
   category: text("category").default("Todo"),
+  label: text("label"),
   priority: integer("priority").default(0),
   due: text("due"),
   recurrence: text("recurrence"),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -93,6 +93,8 @@ export function validateCreateTask(
     data.notes = sanitize(String(b.notes));
   }
   if (b.category !== undefined) data.category = b.category as string;
+  if (b.label !== undefined && b.label !== null)
+    data.label = sanitize(String(b.label).trim());
   if (b.recurrence !== undefined) data.recurrence = b.recurrence as string;
   if (b.recurMode !== undefined)
     data.recurMode = b.recurMode as CreateTaskInput["recurMode"];
@@ -175,6 +177,8 @@ export function validateUpdateTask(
     data.notes = b.notes === null ? null : sanitize(String(b.notes));
   }
   if (b.category !== undefined) data.category = b.category as string | null;
+  if (b.label !== undefined)
+    data.label = b.label === null ? null : sanitize(String(b.label).trim());
   if (b.recurrence !== undefined)
     data.recurrence = b.recurrence as string | null;
   if (b.recurMode !== undefined)

--- a/tests/core/recurrence.test.ts
+++ b/tests/core/recurrence.test.ts
@@ -66,6 +66,7 @@ describe("getNextTaskData", () => {
     description: "Weekly review",
     status: "done",
     category: "Work",
+    label: null,
     priority: 2,
     due: "2026-03-22T09:00:00.000Z",
     recurrence: "FREQ=WEEKLY",

--- a/tests/core/urgency.test.ts
+++ b/tests/core/urgency.test.ts
@@ -21,6 +21,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     description: "Test",
     status: "pending",
     category: "Todo",
+    label: null,
     priority: 0,
     due: null,
     recurrence: null,


### PR DESCRIPTION
## Problem

Categories are broad groupings but lack granularity — a task in UVA can't distinguish between RUTR 2730 and CS 3100.

## Solution

Add `label` text column to tasks. Multiple labels stored comma-separated, rendered as `[label]` brackets in queue/kanban. Searchable via `/`, filterable via `?label=` URL param. Input in create drawer and task detail. Closes #88.