### PR TITLE
fix(ui): calendar hover matches kanban pattern

### DIFF
--- a/src/components/calendar/month-grid.tsx
+++ b/src/components/calendar/month-grid.tsx
@@ -85,7 +85,7 @@ export function MonthGrid({
           return (
             <div
               key={cell.key}
-              className={`flex flex-col p-1.5 text-left transition-colors border-b border-r border-border/30 ${
+              className={`flex flex-col p-1.5 text-left transition-colors border-b border-r border-border/30 hover:bg-accent/50 ${
                 isSelected ? "bg-accent" : isToday ? "bg-primary/10" : ""
               } ${isPast ? "opacity-50" : ""}`}
               style={!isToday && !isSelected ? blend : undefined}

--- a/src/components/calendar/week-time-grid.tsx
+++ b/src/components/calendar/week-time-grid.tsx
@@ -214,8 +214,11 @@ export function WeekTimeGrid({
                 {HOURS.map((h) => (
                   <div
                     key={`line-${h}`}
-                    className="absolute left-0 right-0 border-t border-border/20"
-                    style={{ top: `${h * HOUR_HEIGHT}px` }}
+                    className="absolute left-0 right-0 border-t border-border/20 hover:bg-accent/50 transition-colors"
+                    style={{
+                      top: `${h * HOUR_HEIGHT}px`,
+                      height: `${HOUR_HEIGHT}px`,
+                    }}
                   />
                 ))}
 


### PR DESCRIPTION
## Problem

Calendar had no hover feedback on hour blocks or day cells, unlike kanban's `hover:bg-accent/50`.

## Solution

Add `hover:bg-accent/50` to week view hour blocks (full 60px height) and month view day cells.