### PR TITLE
fix(ui): use outline for today's calendar day cell border

### DIFF
--- a/src/components/calendar/month-grid.tsx
+++ b/src/components/calendar/month-grid.tsx
@@ -87,8 +87,8 @@ export function MonthGrid({
               key={cell.key}
               {...(isSelected ? { "data-calendar-cursor": "" } : {})}
               className={`flex flex-col p-1.5 text-left transition-colors border-b border-r border-border/30 hover:bg-accent/50 ${
-                isSelected ? "bg-accent" : isToday ? "bg-primary/10" : ""
-              } ${isPast ? "opacity-50" : ""}`}
+                isSelected ? "bg-accent" : ""
+              } ${isToday ? "outline outline-1 -outline-offset-1 outline-primary/50" : ""} ${isPast ? "opacity-50" : ""}`}
               style={!isToday && !isSelected ? blend : undefined}
             >
               <span


### PR DESCRIPTION
## Problem

Today's day cell in month view used `bg-primary/10` background tint which was too subtle.

## Solution

Replace with `outline outline-1 -outline-offset-1 outline-primary/50` so today gets a visible border on all four sides without disrupting the grid layout.