### PR TITLE
fix(ui): rebind kanban status keys to w/i/b/x move, W/I/B/X jump

### DIFF
--- a/src/components/global-keyboard.tsx
+++ b/src/components/global-keyboard.tsx
@@ -126,13 +126,13 @@ export function GlobalKeyboard({
         return;
       }
 
-      if (e.key === "w" && pathname !== "/calendar") {
+      if (e.key === "w" && pathname !== "/calendar" && pathname !== "/kanban") {
         e.preventDefault();
         pushJump();
         router.push("/calendar?mode=week");
         return;
       }
-      if (e.key === "m" && pathname !== "/calendar") {
+      if (e.key === "m" && pathname !== "/calendar" && pathname !== "/kanban") {
         e.preventDefault();
         pushJump();
         router.push("/calendar?mode=month");

--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -13,11 +13,18 @@ import { useNavigation } from "@/contexts/navigation";
 import type { Task, TaskStatus } from "@/core/types";
 import { formatDate, isInputFocused } from "@/lib/utils";
 
-const COLUMN_KEYS = ["p", "i", "b", "w"];
-const COLUMN_HINTS = ["P", "I", "B", "W"];
+const COLUMN_KEYS = ["w", "i", "b", "x"];
+const COLUMN_HINTS = ["W", "I", "B", "X"];
+
+const STATUS_FOR_KEY: Record<string, TaskStatus> = {
+  w: "pending",
+  i: "wip",
+  b: "blocked",
+  x: "done",
+};
 
 const defaultColumns: { status: TaskStatus; label: string }[] = [
-  { status: "pending", label: "Pending" },
+  { status: "pending", label: "Waiting" },
   { status: "wip", label: "In Progress" },
   { status: "blocked", label: "Blocked" },
   { status: "done", label: "Done" },
@@ -251,15 +258,44 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
           }
           break;
         }
-        case "p":
+        case "w":
         case "i":
         case "b":
-        case "w": {
+        case "x": {
           e.preventDefault();
-          const ci = COLUMN_KEYS.indexOf(e.key);
-          if (ci !== -1 && ci < columns.length) {
+          if (!kbActive && selectedIds.size === 0) break;
+          const newStatus = STATUS_FOR_KEY[e.key];
+          if (!newStatus) break;
+          if (selectedIds.size > 0) {
+            for (const id of selectedIds) {
+              if (newStatus === "done") completeTaskAction(id);
+              else updateTaskAction(id, { status: newStatus });
+            }
+            setSelectedIds(new Set());
+            setVisualMode(false);
+          } else {
+            const colTasks = getColTasks(colIdx);
+            if (colTasks.length === 0 || rowIdx >= colTasks.length) break;
+            const task = colTasks[rowIdx];
+            if (newStatus === "done") completeTaskAction(task.id);
+            else updateTaskAction(task.id, { status: newStatus });
+          }
+          const targetCol = columns.findIndex((c) => c.status === newStatus);
+          if (targetCol !== -1) {
+            setColIdx(targetCol);
+            setRowIdx(0);
+          }
+          break;
+        }
+        case "W":
+        case "I":
+        case "B":
+        case "X": {
+          e.preventDefault();
+          const jumpIdx = COLUMN_HINTS.indexOf(e.key);
+          if (jumpIdx !== -1 && jumpIdx < columns.length) {
             setKbActive(true);
-            setColIdx(ci);
+            setColIdx(jumpIdx);
             setRowIdx(0);
           }
           break;
@@ -292,20 +328,6 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
               setVisualMode(true);
               visualAnchor.current = rowIdx;
               setSelectedIds(new Set([colTasks[rowIdx].id]));
-            }
-          }
-          break;
-        }
-        case "x": {
-          e.preventDefault();
-          if (selectedIds.size > 0) {
-            for (const id of selectedIds) completeTaskAction(id);
-            setSelectedIds(new Set());
-            setVisualMode(false);
-          } else if (kbActive) {
-            const colTasks = getColTasks(colIdx);
-            if (colTasks.length > 0 && rowIdx < colTasks.length) {
-              completeTaskAction(colTasks[rowIdx].id);
             }
           }
           break;


### PR DESCRIPTION
## Problem

Kanban had no direct keys for moving tasks to a specific status — only `H`/`L` for adjacent column moves. Lowercase `p/i/b/w` jumped to columns, and the Done column hint was incorrectly labeled `W`.

## Solution

Lowercase `w/i/b/x` move the focused task (or visual selection) to Waiting/In Progress/Blocked/Done. Uppercase `W/I/B/X` jump the cursor to that column. Rename "Pending" to "Waiting". Keep `dd` for delete. Exclude `/kanban` from global `w`/`m` calendar shortcuts to prevent conflicts.