### PR TITLE
fix(settings): remove redundant oauth provider configuration section

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -4,7 +4,6 @@ import { validateSession } from "@/core/auth";
 import { getFeedToken } from "@/core/calendar-feed";
 import { getEnabledProviders, getLinkedAccounts } from "@/core/oauth";
 import { remainingRecoveryCodeCount } from "@/core/recovery";
-import { isOAuthProviderConfigured } from "@/core/system-config";
 import { userHasTotp } from "@/core/totp";
 import { getCredentialsForUser } from "@/core/webauthn";
 import { db } from "@/db";
@@ -29,12 +28,6 @@ export default async function SettingsPage() {
   const connectedAccounts = getLinkedAccounts(db, user.id);
   const enabledProviders = getEnabledProviders(db);
 
-  const oauthProviders = {
-    github: isOAuthProviderConfigured(db, "github"),
-    google: isOAuthProviderConfigured(db, "google"),
-    gitlab: isOAuthProviderConfigured(db, "gitlab"),
-  };
-
   return (
     <SettingsView
       username={user.username}
@@ -44,7 +37,6 @@ export default async function SettingsPage() {
       calendarFeedToken={calendarFeedToken}
       connectedAccounts={connectedAccounts}
       enabledProviders={enabledProviders}
-      oauthProviders={oauthProviders}
     />
   );
 }

--- a/src/app/(dashboard)/settings/settings-view.tsx
+++ b/src/app/(dashboard)/settings/settings-view.tsx
@@ -25,12 +25,6 @@ interface ConnectedAccount {
   createdAt: string;
 }
 
-type OAuthProviderStatus = {
-  github: boolean;
-  google: boolean;
-  gitlab: boolean;
-};
-
 export function SettingsView({
   username,
   passkeys: initialPasskeys,
@@ -39,7 +33,6 @@ export function SettingsView({
   calendarFeedToken: initialFeedToken,
   connectedAccounts: initialConnectedAccounts,
   enabledProviders,
-  oauthProviders: initialOAuthProviders,
 }: {
   username: string;
   passkeys: Passkey[];
@@ -48,7 +41,6 @@ export function SettingsView({
   calendarFeedToken: string | null;
   connectedAccounts: ConnectedAccount[];
   enabledProviders: string[];
-  oauthProviders: OAuthProviderStatus;
 }) {
   const router = useRouter();
   const [passkeys, setPasskeys] = useState(initialPasskeys);
@@ -57,7 +49,6 @@ export function SettingsView({
     initialRecoveryRemaining,
   );
   const [feedToken, setFeedToken] = useState(initialFeedToken);
-  const [oauthProviders, setOAuthProviders] = useState(initialOAuthProviders);
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
 
@@ -75,9 +66,6 @@ export function SettingsView({
   const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
   const [invites, setInvites] = useState<InviteLinkRow[]>([]);
   const [invitesLoaded, setInvitesLoaded] = useState(false);
-  const [editingProvider, setEditingProvider] = useState<string | null>(null);
-  const [oauthClientId, setOAuthClientId] = useState("");
-  const [oauthClientSecret, setOAuthClientSecret] = useState("");
   const [icalCategory, setIcalCategory] = useState("");
   const [icalImporting, setIcalImporting] = useState(false);
   const icalFileRef = useRef<HTMLInputElement>(null);
@@ -250,57 +238,6 @@ export function SettingsView({
     loadInvites();
   }, [loadInvites]);
 
-  function handleEditOAuthProvider(provider: string) {
-    setEditingProvider(provider);
-    setOAuthClientId("");
-    setOAuthClientSecret("");
-  }
-
-  async function handleSaveOAuthProvider() {
-    if (!editingProvider) return;
-
-    const res = await fetch(`/api/settings/oauth/${editingProvider}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        clientId: oauthClientId,
-        clientSecret: oauthClientSecret,
-      }),
-    });
-
-    if (!res.ok) {
-      const data = await res.json();
-      flashError(data.error ?? "Failed to save credentials");
-      return;
-    }
-
-    setOAuthProviders((prev) => ({
-      ...prev,
-      [editingProvider]: true,
-    }));
-    setEditingProvider(null);
-    setOAuthClientId("");
-    setOAuthClientSecret("");
-    flash(`${editingProvider} configured`);
-  }
-
-  async function handleRemoveOAuthProvider(provider: string) {
-    const res = await fetch(`/api/settings/oauth/${provider}`, {
-      method: "DELETE",
-    });
-
-    if (!res.ok) {
-      const data = await res.json();
-      flashError(data.error ?? "Failed to remove credentials");
-      return;
-    }
-
-    setOAuthProviders((prev) => ({
-      ...prev,
-      [provider]: false,
-    }));
-    flash(`${provider} removed`);
-  }
   async function handleIcalImport() {
     const file = icalFileRef.current?.files?.[0];
     if (!file) {
@@ -550,87 +487,6 @@ export function SettingsView({
               onClick={handleRegenerateRecovery}
             />
           )}
-        </Section>
-
-        <Section title="oauth providers">
-          {(["github", "google", "gitlab"] as const).map((provider) => (
-            <div key={provider}>
-              {editingProvider === provider ? (
-                <div className="mb-3">
-                  <div className="text-sm text-foreground mb-2">{provider}</div>
-                  <div className="flex flex-col gap-2 ml-4">
-                    <Input
-                      value={oauthClientId}
-                      onChange={(e) => setOAuthClientId(e.target.value)}
-                      placeholder="client id"
-                      autoFocus
-                      className="h-7 text-sm"
-                      onKeyDown={(e) => {
-                        if (e.key === "Escape") setEditingProvider(null);
-                      }}
-                    />
-                    <Input
-                      value={oauthClientSecret}
-                      onChange={(e) => setOAuthClientSecret(e.target.value)}
-                      placeholder="client secret"
-                      type="password"
-                      className="h-7 text-sm"
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleSaveOAuthProvider();
-                        if (e.key === "Escape") setEditingProvider(null);
-                      }}
-                    />
-                    <div className="flex gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleSaveOAuthProvider}
-                        className="h-7 text-xs"
-                      >
-                        save
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setEditingProvider(null)}
-                        className="h-7 text-xs"
-                      >
-                        cancel
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center w-full text-sm py-1 px-2">
-                  <span className="flex-1 text-left truncate min-w-0 text-foreground">
-                    {provider}
-                  </span>
-                  <span className="text-muted-foreground shrink-0 mr-2">
-                    {oauthProviders[provider] ? "configured" : "not configured"}
-                  </span>
-                  {oauthProviders[provider] ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleRemoveOAuthProvider(provider)}
-                      className="h-6 text-xs px-2"
-                    >
-                      remove
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleEditOAuthProvider(provider)}
-                      className="h-6 text-xs px-2"
-                    >
-                      configure
-                    </Button>
-                  )}
-                </div>
-              )}
-            </div>
-          ))}
         </Section>
 
         <Section title="calendar feed">


### PR DESCRIPTION
## Problem

The settings page had an "OAuth Providers" section displaying provider configuration status (configured/not configured) with configure/remove buttons. OAuth providers are configured during deployment via env vars or the `systemConfigs` table — not by end users in the settings UI. In a self-hosted single-user app this section is redundant noise.

## Solution

Remove the "OAuth Providers" `<Section>` block, its associated state (`oauthProviders`, `editingProvider`, `oauthClientId`, `oauthClientSecret`), the three handler functions (`handleEditOAuthProvider`, `handleSaveOAuthProvider`, `handleRemoveOAuthProvider`), the `OAuthProviderStatus` type, and the `oauthProviders` prop from the server component. The "Connected Accounts" section and the `/api/settings/oauth/[provider]` API routes are untouched.

Closes #151