### PR TITLE
refactor(calendar): move ical import/export to calendar view

### DIFF
--- a/src/app/(dashboard)/settings/settings-view.tsx
+++ b/src/app/(dashboard)/settings/settings-view.tsx
@@ -2,7 +2,7 @@
 
 import { startRegistration } from "@simplewebauthn/browser";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   generateInviteAction,
   type InviteLinkRow,
@@ -78,9 +78,6 @@ export function SettingsView({
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
   const [oauthClientId, setOAuthClientId] = useState("");
   const [oauthClientSecret, setOAuthClientSecret] = useState("");
-  const [icalCategory, setIcalCategory] = useState("");
-  const [icalImporting, setIcalImporting] = useState(false);
-  const icalFileRef = useRef<HTMLInputElement>(null);
 
   const flash = useCallback((msg: string) => {
     setMessage(msg);
@@ -301,35 +298,6 @@ export function SettingsView({
     }));
     flash(`${provider} removed`);
   }
-  async function handleIcalImport() {
-    const file = icalFileRef.current?.files?.[0];
-    if (!file) {
-      flashError("select a .ics file first");
-      return;
-    }
-    setIcalImporting(true);
-    try {
-      const body = new FormData();
-      body.append("file", file);
-      if (icalCategory.trim()) body.append("category", icalCategory.trim());
-      const res = await fetch("/api/import/ical", { method: "POST", body });
-      const data = await res.json();
-      if (!res.ok) {
-        flashError(data.error ?? "import failed");
-        return;
-      }
-      flash(
-        `imported ${data.created} events, skipped ${data.skipped} duplicates`,
-      );
-      if (icalFileRef.current) icalFileRef.current.value = "";
-      setIcalCategory("");
-    } catch (e) {
-      flashError(e instanceof Error ? e.message : "import failed");
-    } finally {
-      setIcalImporting(false);
-    }
-  }
-
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement) return;
@@ -662,35 +630,6 @@ export function SettingsView({
               onClick={handleGenerateFeed}
             />
           )}
-        </Section>
-
-        <Section title="import">
-          <div className="flex flex-col gap-2 px-2">
-            <Input
-              ref={icalFileRef}
-              type="file"
-              accept=".ics"
-              className="h-8 text-sm"
-            />
-            <Input
-              value={icalCategory}
-              onChange={(e) => setIcalCategory(e.target.value)}
-              placeholder="category (optional)"
-              className="h-7 text-sm"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleIcalImport();
-              }}
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleIcalImport}
-              disabled={icalImporting}
-              className="h-7 text-xs w-full"
-            >
-              {icalImporting ? "importing..." : "import .ics"}
-            </Button>
-          </div>
         </Section>
 
         <Section title="invites">

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -9,6 +9,7 @@ import {
 import { AllDayBar } from "@/components/calendar/all-day-bar";
 import { MonthGrid } from "@/components/calendar/month-grid";
 import { WeekTimeGrid } from "@/components/calendar/week-time-grid";
+import { IcalPopover } from "@/components/ical-popover";
 import { RecurrenceStrategyDialog } from "@/components/recurrence-strategy-dialog";
 import { useNavigation } from "@/contexts/navigation";
 import { useTaskPanel } from "@/contexts/task-panel";
@@ -742,8 +743,14 @@ export function CalendarView({
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-center px-6 py-3 border-b border-border/60 shrink-0">
-        <h2 className="text-lg font-semibold tracking-tight">{headerTitle}</h2>
+      <div className="flex items-center px-6 py-3 border-b border-border/60 shrink-0">
+        <div className="w-12 shrink-0" />
+        <h2 className="text-lg font-semibold tracking-tight flex-1 text-center">
+          {headerTitle}
+        </h2>
+        <div className="w-12 shrink-0 flex justify-end">
+          <IcalPopover />
+        </div>
       </div>
 
       {viewMode === "week" && allDayTasks.length > 0 && (

--- a/src/components/ical-popover.tsx
+++ b/src/components/ical-popover.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export function IcalPopover() {
+  const [category, setCategory] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function flash(msg: string) {
+    setMessage(msg);
+    setError("");
+    setTimeout(() => setMessage(""), 3000);
+  }
+
+  function flashError(msg: string) {
+    setError(msg);
+    setMessage("");
+    setTimeout(() => setError(""), 5000);
+  }
+
+  async function handleImport() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      flashError("select a .ics file first");
+      return;
+    }
+    setImporting(true);
+    try {
+      const body = new FormData();
+      body.append("file", file);
+      if (category.trim()) body.append("category", category.trim());
+      const res = await fetch("/api/import/ical", { method: "POST", body });
+      const data = await res.json();
+      if (!res.ok) {
+        flashError(data.error ?? "import failed");
+        return;
+      }
+      flash(
+        `imported ${data.created} events, skipped ${data.skipped} duplicates`,
+      );
+      if (fileRef.current) fileRef.current.value = "";
+      setCategory("");
+    } catch (e) {
+      flashError(e instanceof Error ? e.message : "import failed");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function handleExport() {
+    window.location.href = "/api/export/ical";
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button variant="ghost" size="xs" className="text-muted-foreground" />
+        }
+      >
+        ical
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64">
+        <div className="flex flex-col gap-3">
+          <div className="text-xs text-muted-foreground uppercase tracking-wider">
+            export
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExport}
+            className="h-7 text-xs w-full"
+          >
+            export .ics
+          </Button>
+
+          <div className="h-px bg-border" />
+
+          <div className="text-xs text-muted-foreground uppercase tracking-wider">
+            import
+          </div>
+          <Input
+            ref={fileRef}
+            type="file"
+            accept=".ics"
+            className="h-8 text-sm"
+          />
+          <Input
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            placeholder="category (optional)"
+            className="h-7 text-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleImport();
+            }}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleImport}
+            disabled={importing}
+            className="h-7 text-xs w-full"
+          >
+            {importing ? "importing..." : "import .ics"}
+          </Button>
+
+          {(error || message) && (
+            <div
+              className={`text-xs ${error ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {error || message}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Problem

iCal import/export controls lived in the settings page alongside account settings like passkeys and OAuth. These are calendar operations and belong with the calendar view.

## Solution

Extract import/export into an `IcalPopover` component in the calendar header. A ghost button labeled "ical" opens a popover with export (downloads .ics via `GET /api/export/ical`) and import (file picker + optional category, same `POST /api/import/ical` endpoint). Calendar feed token management (generate/copy/revoke) stays in settings since it is an integration concern.

Closes #152