### PR TITLE
refactor(calendar): move feed management from settings to calendar view

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { validateSession } from "@/core/auth";
-import { getFeedToken } from "@/core/calendar-feed";
 import { getEnabledProviders, getLinkedAccounts } from "@/core/oauth";
 import { remainingRecoveryCodeCount } from "@/core/recovery";
 import { isOAuthProviderConfigured } from "@/core/system-config";
@@ -25,7 +24,6 @@ export default async function SettingsPage() {
   }));
   const totpEnabled = userHasTotp(db, user.id);
   const recoveryCodesRemaining = remainingRecoveryCodeCount(db, user.id);
-  const calendarFeedToken = getFeedToken(db, user.id);
   const connectedAccounts = getLinkedAccounts(db, user.id);
   const enabledProviders = getEnabledProviders(db);
 
@@ -41,7 +39,6 @@ export default async function SettingsPage() {
       passkeys={passkeys}
       totpEnabled={totpEnabled}
       recoveryCodesRemaining={recoveryCodesRemaining}
-      calendarFeedToken={calendarFeedToken}
       connectedAccounts={connectedAccounts}
       enabledProviders={enabledProviders}
       oauthProviders={oauthProviders}

--- a/src/app/(dashboard)/settings/settings-view.tsx
+++ b/src/app/(dashboard)/settings/settings-view.tsx
@@ -36,7 +36,6 @@ export function SettingsView({
   passkeys: initialPasskeys,
   totpEnabled: initialTotpEnabled,
   recoveryCodesRemaining: initialRecoveryRemaining,
-  calendarFeedToken: initialFeedToken,
   connectedAccounts: initialConnectedAccounts,
   enabledProviders,
   oauthProviders: initialOAuthProviders,
@@ -45,7 +44,6 @@ export function SettingsView({
   passkeys: Passkey[];
   totpEnabled: boolean;
   recoveryCodesRemaining: number;
-  calendarFeedToken: string | null;
   connectedAccounts: ConnectedAccount[];
   enabledProviders: string[];
   oauthProviders: OAuthProviderStatus;
@@ -56,7 +54,6 @@ export function SettingsView({
   const [recoveryRemaining, setRecoveryRemaining] = useState(
     initialRecoveryRemaining,
   );
-  const [feedToken, setFeedToken] = useState(initialFeedToken);
   const [oauthProviders, setOAuthProviders] = useState(initialOAuthProviders);
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
@@ -181,29 +178,6 @@ export function SettingsView({
     setRecoveryCodes(data.codes);
     setRecoveryRemaining(data.codes.length);
     setShowRecoveryCodes(true);
-  }
-
-  function getFeedUrl(token: string): string {
-    return `${window.location.origin}/api/calendar/feed/${token}`;
-  }
-
-  async function handleGenerateFeed() {
-    const res = await fetch("/api/calendar/feed", { method: "POST" });
-    const data = await res.json();
-    setFeedToken(data.token);
-    flash("feed URL generated");
-  }
-
-  async function handleRevokeFeed() {
-    await fetch("/api/calendar/feed", { method: "DELETE" });
-    setFeedToken(null);
-    flash("feed URL revoked");
-  }
-
-  async function handleCopyFeedUrl() {
-    if (!feedToken) return;
-    await navigator.clipboard.writeText(getFeedUrl(feedToken));
-    flash("copied to clipboard");
   }
 
   async function handleUnlinkProvider(provider: string) {
@@ -350,14 +324,6 @@ export function SettingsView({
         case "r":
           e.preventDefault();
           handleRegenerateRecovery();
-          break;
-        case "c":
-          e.preventDefault();
-          if (feedToken) {
-            handleCopyFeedUrl();
-          } else {
-            handleGenerateFeed();
-          }
           break;
         case "i":
           e.preventDefault();
@@ -631,37 +597,6 @@ export function SettingsView({
               )}
             </div>
           ))}
-        </Section>
-
-        <Section title="calendar feed">
-          {feedToken ? (
-            <>
-              <div className="text-xs text-muted-foreground break-all select-all px-2 py-1 border border-border mb-2 font-mono">
-                {getFeedUrl(feedToken)}
-              </div>
-              <Row
-                label="copy URL"
-                hint="c"
-                action
-                onClick={handleCopyFeedUrl}
-              />
-              <Row
-                label="regenerate"
-                action
-                muted
-                onClick={handleGenerateFeed}
-              />
-              <Row label="disable" action muted onClick={handleRevokeFeed} />
-            </>
-          ) : (
-            <Row
-              label="enable calendar feed"
-              hint="c"
-              action
-              muted
-              onClick={handleGenerateFeed}
-            />
-          )}
         </Section>
 
         <Section title="import">

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -7,6 +7,7 @@ import {
   updateTaskAction,
 } from "@/app/actions/tasks";
 import { AllDayBar } from "@/components/calendar/all-day-bar";
+import { CalendarFeedPopover } from "@/components/calendar/feed-popover";
 import { MonthGrid } from "@/components/calendar/month-grid";
 import { WeekTimeGrid } from "@/components/calendar/week-time-grid";
 import { RecurrenceStrategyDialog } from "@/components/recurrence-strategy-dialog";
@@ -742,8 +743,12 @@ export function CalendarView({
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-center px-6 py-3 border-b border-border/60 shrink-0">
+      <div className="flex items-center px-6 py-3 border-b border-border/60 shrink-0">
+        <div className="flex-1" />
         <h2 className="text-lg font-semibold tracking-tight">{headerTitle}</h2>
+        <div className="flex-1 flex justify-end">
+          <CalendarFeedPopover />
+        </div>
       </div>
 
       {viewMode === "week" && allDayTasks.length > 0 && (

--- a/src/components/calendar/feed-popover.tsx
+++ b/src/components/calendar/feed-popover.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export function CalendarFeedPopover() {
+  const [feedToken, setFeedToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    const res = await fetch("/api/calendar/feed");
+    const data = await res.json();
+    setFeedToken(data.token);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  function getFeedUrl(token: string): string {
+    return `${window.location.origin}/api/calendar/feed/${token}`;
+  }
+
+  async function handleGenerate() {
+    const res = await fetch("/api/calendar/feed", { method: "POST" });
+    const data = await res.json();
+    setFeedToken(data.token);
+  }
+
+  async function handleRevoke() {
+    await fetch("/api/calendar/feed", { method: "DELETE" });
+    setFeedToken(null);
+    setCopied(false);
+  }
+
+  async function handleCopy() {
+    if (!feedToken) return;
+    await navigator.clipboard.writeText(getFeedUrl(feedToken));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  if (loading) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="text-xs text-muted-foreground"
+        >
+          feed
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-3">
+        {feedToken ? (
+          <div className="flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="w-full text-left text-[11px] text-muted-foreground break-all select-all px-2 py-1.5 border border-border font-mono hover:bg-muted/50 cursor-pointer transition-colors"
+            >
+              {copied ? "copied" : getFeedUrl(feedToken)}
+            </button>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                size="xs"
+                className="flex-1 text-xs text-muted-foreground"
+                onClick={handleGenerate}
+              >
+                regenerate
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                className="flex-1 text-xs text-muted-foreground"
+                onClick={handleRevoke}
+              >
+                revoke
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="w-full text-xs text-muted-foreground"
+            onClick={handleGenerate}
+          >
+            enable calendar feed
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Problem

The calendar feed section (generate/copy/revoke token) lived in settings despite being a calendar-specific feature. The feed URL was displayed as selectable text rather than a proper click-to-copy element.

## Solution

Extract feed management into a `CalendarFeedPopover` component in the calendar view header. The popover fetches feed status via `GET /api/calendar/feed` on mount and provides generate, click-to-copy (with "copied" feedback), regenerate, and revoke actions. The calendar feed section and its `c` keybinding are removed from settings entirely.

Closes #153