### PR TITLE
fix(keyboard): let browser-native shortcuts pass through handlers

### DIFF
--- a/src/app/(dashboard)/settings/settings-view.tsx
+++ b/src/app/(dashboard)/settings/settings-view.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/actions/invites";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { isBrowserShortcut } from "@/lib/utils";
 
 interface Passkey {
   id: number;
@@ -333,6 +334,7 @@ export function SettingsView({
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.target instanceof HTMLInputElement) return;
+      if (isBrowserShortcut(e)) return;
 
       switch (e.key) {
         case "q":

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -35,7 +35,7 @@ import {
   minuteToISOString,
   startOfMonth,
 } from "@/lib/calendar-utils";
-import { isInputFocused } from "@/lib/utils";
+import { isBrowserShortcut, isInputFocused } from "@/lib/utils";
 
 type ViewMode = "week" | "month";
 
@@ -510,6 +510,7 @@ export function CalendarView({
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
+      if (isBrowserShortcut(e)) return;
 
       if (e.ctrlKey && viewMode === "week" && weekScrollRef.current) {
         const el = weekScrollRef.current;

--- a/src/components/global-keyboard.tsx
+++ b/src/components/global-keyboard.tsx
@@ -7,7 +7,7 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useNavigation } from "@/contexts/navigation";
 import { useTaskPanel } from "@/contexts/task-panel";
 import { useUndo } from "@/contexts/undo";
-import { isInputFocused } from "@/lib/utils";
+import { isBrowserShortcut, isInputFocused } from "@/lib/utils";
 
 const VIEW_KEYS: Record<string, string> = {
   Q: "/",
@@ -32,6 +32,7 @@ export function GlobalKeyboard({ categories = [] }: { categories?: string[] }) {
   const handler = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
+      if (isBrowserShortcut(e)) return;
 
       if (e.ctrlKey) {
         if (e.key === "o") {

--- a/src/components/kanban-board.tsx
+++ b/src/components/kanban-board.tsx
@@ -15,7 +15,7 @@ import { useUndo } from "@/contexts/undo";
 import type { Task, TaskStatus } from "@/core/types";
 import type { UndoMutation } from "@/core/undo";
 import { useRecurrenceDelete } from "@/hooks/use-recurrence-delete";
-import { formatDate, isInputFocused } from "@/lib/utils";
+import { formatDate, isBrowserShortcut, isInputFocused } from "@/lib/utils";
 
 const COLUMN_HINTS = ["W", "I", "B", "X"];
 
@@ -196,6 +196,7 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
   const handler = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
+      if (isBrowserShortcut(e)) return;
       if (panel.isOpen) return;
 
       if (pendingOp.current) {

--- a/src/hooks/use-keyboard.ts
+++ b/src/hooks/use-keyboard.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Task, TaskStatus } from "@/core/types";
-import { isInputFocused } from "@/lib/utils";
+import { isBrowserShortcut, isInputFocused } from "@/lib/utils";
 
 const STATUS_OPS: Record<string, TaskStatus> = {
   p: "pending",
@@ -148,6 +148,7 @@ export function useKeyboard(actions: KeyboardActions) {
   const handler = useCallback(
     (e: KeyboardEvent) => {
       if (isInputFocused()) return;
+      if (isBrowserShortcut(e)) return;
 
       const { tasks, onSelect, onDeselect, onCreate } = actionsRef.current;
       const isModifier = ["Shift", "Control", "Alt", "Meta"].includes(e.key);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -100,3 +100,28 @@ export function formatRelativeDate(date: Date): string {
 export function isOverdue(due: string): boolean {
   return new Date(due) < new Date(new Date().toDateString());
 }
+
+const BROWSER_CTRL_KEYS = new Set([
+  "-",
+  "=",
+  "+",
+  "0",
+  "t",
+  "w",
+  "n",
+  "l",
+  "r",
+  "f",
+  "p",
+  "Tab",
+]);
+
+const BROWSER_CTRL_SHIFT_KEYS = new Set(["I", "R", "Tab", "J", "T", "N"]);
+
+export function isBrowserShortcut(e: KeyboardEvent): boolean {
+  if (e.altKey && ["ArrowLeft", "ArrowRight"].includes(e.key)) return true;
+  if (e.key === "F5" || e.key === "F11" || e.key === "F12") return true;
+  if (!e.ctrlKey && !e.metaKey) return false;
+  if (e.shiftKey && BROWSER_CTRL_SHIFT_KEYS.has(e.key)) return true;
+  return BROWSER_CTRL_KEYS.has(e.key);
+}


### PR DESCRIPTION
## Problem

Delta's keyboard handlers intercept browser-native shortcuts like `Ctrl+-` (zoom out), `Ctrl+T` (new tab), `Ctrl+W` (close tab), and others. The root cause is that handlers check `e.key` without modifier guards -- for example, pressing `Ctrl+-` matches `e.key === "-"` in `global-keyboard.tsx` and toggles the sidebar instead of zooming out.

## Solution

Add a centralized `isBrowserShortcut()` utility in `src/lib/utils.ts` that detects browser-native key combinations (zoom, tab/window management, address bar, reload, find, print, devtools, F-keys, and `Alt+Arrow` for browser back/forward). Guard all five `window.addEventListener("keydown")` handlers with an early return when a browser shortcut is detected.

Closes #154