### PR TITLE
revert(ci): restore GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,14 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command biome check .
 
   typecheck:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -27,7 +27,7 @@ jobs:
       - run: nix develop --command pnpm tsc --noEmit
 
   test:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -35,7 +35,7 @@ jobs:
       - run: nix develop --command pnpm vitest run --reporter=verbose --coverage.enabled --coverage.reporter=text
 
   build:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
       - run: nix develop --command pnpm build
 
   deploy:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
@@ -30,7 +30,7 @@ jobs:
           fi
 
   lint:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: check
     if: needs.check.outputs.has_changes == 'true'
     steps:
@@ -39,7 +39,7 @@ jobs:
       - run: nix develop --command biome check .
 
   typecheck:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: check
     if: needs.check.outputs.has_changes == 'true'
     steps:
@@ -49,7 +49,7 @@ jobs:
       - run: nix develop --command pnpm tsc --noEmit
 
   test:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: check
     if: needs.check.outputs.has_changes == 'true'
     steps:
@@ -59,7 +59,7 @@ jobs:
       - run: nix develop --command pnpm vitest run --reporter=verbose --coverage.enabled --coverage.reporter=text
 
   build:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
       - run: nix develop --command pnpm build
 
   nightly:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -68,7 +68,7 @@ jobs:
           fi
 
   release:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'workflow_dispatch'
     permissions:
@@ -133,7 +133,7 @@ jobs:
           echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
 
   npm-publish:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: [build, release]
     if: github.event_name == 'workflow_dispatch'
     permissions:
@@ -178,7 +178,7 @@ jobs:
         run: npm publish --provenance --access public
 
   npm-publish-tag:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/cli-v')
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,14 @@ permissions:
 
 jobs:
   lint:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command biome check .
 
   typecheck:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -24,7 +24,7 @@ jobs:
       - run: nix develop --command pnpm tsc --noEmit
 
   test:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -32,7 +32,7 @@ jobs:
       - run: nix develop --command pnpm vitest run --reporter=verbose --coverage.enabled --coverage.reporter=text
 
   build:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       - run: nix develop --command pnpm build
 
   release:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- revert the self-hosted runner migration
- restore GitHub-hosted workflow execution for this repo
- remove the netcup runner dependency from CI

#### Test plan
- [x] Confirmed the revert removes `self-hosted` from the workflow files