### PR TITLE
feat(reminders): add reminder foundations

### DIFF
--- a/drizzle/0026_reminder_core.sql
+++ b/drizzle/0026_reminder_core.sql
@@ -1,0 +1,50 @@
+CREATE TABLE `reminder_endpoints` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `user_id` integer NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `adapter_key` text NOT NULL,
+  `label` text NOT NULL,
+  `encrypted_target` text NOT NULL,
+  `metadata` text,
+  `enabled` integer DEFAULT 1 NOT NULL,
+  `last_test_at` text,
+  `last_test_status` text,
+  `last_test_error` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `task_reminders` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `user_id` integer NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `task_id` integer NOT NULL REFERENCES `tasks`(`id`) ON DELETE CASCADE,
+  `endpoint_id` integer NOT NULL REFERENCES `reminder_endpoints`(`id`) ON DELETE CASCADE,
+  `anchor` text NOT NULL,
+  `offset_minutes` integer NOT NULL,
+  `all_day_local_time` text,
+  `enabled` integer DEFAULT 1 NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `reminder_deliveries` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `user_id` integer NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `task_id` integer NOT NULL REFERENCES `tasks`(`id`) ON DELETE CASCADE,
+  `task_reminder_id` integer NOT NULL REFERENCES `task_reminders`(`id`) ON DELETE CASCADE,
+  `endpoint_id` integer NOT NULL REFERENCES `reminder_endpoints`(`id`) ON DELETE CASCADE,
+  `adapter_key` text NOT NULL,
+  `dedupe_key` text NOT NULL,
+  `scheduled_for` text NOT NULL,
+  `status` text DEFAULT 'pending' NOT NULL,
+  `attempts` integer DEFAULT 0 NOT NULL,
+  `next_attempt_at` text,
+  `provider_message_id` text,
+  `rendered_body` text,
+  `error` text,
+  `last_attempt_at` text,
+  `sent_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `reminder_deliveries_dedupe_key_unique` ON `reminder_deliveries` (`dedupe_key`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1774915200012,
       "tag": "0025_onboarding_completed",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1775500000000,
+      "tag": "0026_reminder_core",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/reminders/endpoints.ts
+++ b/src/core/reminders/endpoints.ts
@@ -1,0 +1,198 @@
+import { and, eq } from "drizzle-orm";
+import { decrypt, encrypt, getEncryptionKey } from "@/core/encryption";
+import { reminderEndpoints } from "@/db/schema";
+import type { Db } from "../types";
+import type { ReminderAdapterKey, ReminderTestStatus } from "./types";
+
+export interface ReminderEndpointRecord {
+  id: number;
+  userId: number;
+  adapterKey: ReminderAdapterKey;
+  label: string;
+  target: string;
+  metadata: Record<string, unknown> | null;
+  enabled: number;
+  lastTestAt: string | null;
+  lastTestStatus: ReminderTestStatus | null;
+  lastTestError: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateReminderEndpointInput {
+  adapterKey: ReminderAdapterKey;
+  label: string;
+  target: string;
+  metadata?: Record<string, unknown>;
+  enabled?: number;
+}
+
+export interface UpdateReminderEndpointInput {
+  label?: string;
+  target?: string;
+  metadata?: Record<string, unknown> | null;
+  enabled?: number;
+}
+
+function mapEndpoint(
+  row: typeof reminderEndpoints.$inferSelect,
+): ReminderEndpointRecord {
+  const key = getEncryptionKey();
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    adapterKey: row.adapterKey,
+    label: row.label,
+    target: decrypt(row.encryptedTarget, key),
+    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    enabled: row.enabled,
+    lastTestAt: row.lastTestAt,
+    lastTestStatus: row.lastTestStatus,
+    lastTestError: row.lastTestError,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createReminderEndpoint(
+  db: Db,
+  userId: number,
+  input: CreateReminderEndpointInput,
+): ReminderEndpointRecord {
+  const key = getEncryptionKey();
+  const now = new Date().toISOString();
+
+  const row = db
+    .insert(reminderEndpoints)
+    .values({
+      userId,
+      adapterKey: input.adapterKey,
+      label: input.label,
+      encryptedTarget: encrypt(input.target, key),
+      metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+      enabled: input.enabled ?? 1,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .get();
+
+  return mapEndpoint(row);
+}
+
+export function getReminderEndpoint(
+  db: Db,
+  userId: number,
+  id: number,
+): ReminderEndpointRecord | null {
+  const row = db
+    .select()
+    .from(reminderEndpoints)
+    .where(
+      and(eq(reminderEndpoints.userId, userId), eq(reminderEndpoints.id, id)),
+    )
+    .get();
+
+  return row ? mapEndpoint(row) : null;
+}
+
+export function listReminderEndpoints(
+  db: Db,
+  userId: number,
+): ReminderEndpointRecord[] {
+  return db
+    .select()
+    .from(reminderEndpoints)
+    .where(eq(reminderEndpoints.userId, userId))
+    .all()
+    .map(mapEndpoint);
+}
+
+export function updateReminderEndpoint(
+  db: Db,
+  userId: number,
+  id: number,
+  input: UpdateReminderEndpointInput,
+): ReminderEndpointRecord | null {
+  const existing = db
+    .select()
+    .from(reminderEndpoints)
+    .where(
+      and(eq(reminderEndpoints.userId, userId), eq(reminderEndpoints.id, id)),
+    )
+    .get();
+
+  if (!existing) return null;
+
+  const key = getEncryptionKey();
+  const row = db
+    .update(reminderEndpoints)
+    .set({
+      label: input.label ?? existing.label,
+      encryptedTarget:
+        input.target !== undefined
+          ? encrypt(input.target, key)
+          : existing.encryptedTarget,
+      metadata:
+        input.metadata === undefined
+          ? existing.metadata
+          : input.metadata === null
+            ? null
+            : JSON.stringify(input.metadata),
+      enabled: input.enabled ?? existing.enabled,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(reminderEndpoints.id, existing.id))
+    .returning()
+    .get();
+
+  return mapEndpoint(row);
+}
+
+export function setReminderEndpointTestResult(
+  db: Db,
+  userId: number,
+  id: number,
+  status: ReminderTestStatus,
+  error?: string | null,
+): ReminderEndpointRecord | null {
+  const existing = db
+    .select()
+    .from(reminderEndpoints)
+    .where(
+      and(eq(reminderEndpoints.userId, userId), eq(reminderEndpoints.id, id)),
+    )
+    .get();
+
+  if (!existing) return null;
+
+  const row = db
+    .update(reminderEndpoints)
+    .set({
+      lastTestAt: new Date().toISOString(),
+      lastTestStatus: status,
+      lastTestError: error ?? null,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(reminderEndpoints.id, existing.id))
+    .returning()
+    .get();
+
+  return mapEndpoint(row);
+}
+
+export function deleteReminderEndpoint(
+  db: Db,
+  userId: number,
+  id: number,
+): boolean {
+  const result = db
+    .delete(reminderEndpoints)
+    .where(
+      and(eq(reminderEndpoints.userId, userId), eq(reminderEndpoints.id, id)),
+    )
+    .run();
+
+  return result.changes > 0;
+}

--- a/src/core/reminders/registry.ts
+++ b/src/core/reminders/registry.ts
@@ -1,0 +1,88 @@
+import type { ReminderAdapterManifest } from "./types";
+
+const MANIFESTS = [
+  {
+    key: "sms.twilio",
+    channel: "sms",
+    displayName: "Twilio SMS",
+    configScope: "system",
+    capabilities: {
+      supportsDeliveryStatus: true,
+      supportsRichText: false,
+      supportsTestSend: true,
+      beta: false,
+    },
+  },
+  {
+    key: "signal.signal_cli",
+    channel: "signal",
+    displayName: "Signal CLI",
+    configScope: "system",
+    capabilities: {
+      supportsDeliveryStatus: false,
+      supportsRichText: false,
+      supportsTestSend: true,
+      beta: true,
+    },
+  },
+  {
+    key: "telegram.bot_api",
+    channel: "telegram",
+    displayName: "Telegram Bot API",
+    configScope: "system",
+    capabilities: {
+      supportsDeliveryStatus: false,
+      supportsRichText: false,
+      supportsTestSend: true,
+      beta: false,
+    },
+  },
+  {
+    key: "discord.webhook",
+    channel: "discord",
+    displayName: "Discord Webhook",
+    configScope: "none",
+    capabilities: {
+      supportsDeliveryStatus: false,
+      supportsRichText: false,
+      supportsTestSend: true,
+      beta: false,
+    },
+  },
+  {
+    key: "slack.webhook",
+    channel: "slack",
+    displayName: "Slack Webhook",
+    configScope: "none",
+    capabilities: {
+      supportsDeliveryStatus: false,
+      supportsRichText: false,
+      supportsTestSend: true,
+      beta: false,
+    },
+  },
+] satisfies ReminderAdapterManifest[];
+
+const MANIFEST_BY_KEY = new Map<string, ReminderAdapterManifest>(
+  MANIFESTS.map((manifest) => [manifest.key, manifest]),
+);
+
+function cloneManifest(
+  manifest: ReminderAdapterManifest,
+): ReminderAdapterManifest {
+  return {
+    ...manifest,
+    capabilities: { ...manifest.capabilities },
+  };
+}
+
+export function listReminderAdapters(): ReminderAdapterManifest[] {
+  return MANIFESTS.map(cloneManifest);
+}
+
+export function getReminderAdapter(
+  key: string,
+): ReminderAdapterManifest | null {
+  const manifest = MANIFEST_BY_KEY.get(key);
+  return manifest ? cloneManifest(manifest) : null;
+}

--- a/src/core/reminders/rules.ts
+++ b/src/core/reminders/rules.ts
@@ -1,0 +1,137 @@
+import { and, eq } from "drizzle-orm";
+import { taskReminders } from "@/db/schema";
+import type { Db } from "../types";
+import type { ReminderAnchor, TaskReminder } from "./types";
+
+export interface CreateTaskReminderInput {
+  taskId: number;
+  endpointId: number;
+  anchor: ReminderAnchor;
+  offsetMinutes: number;
+  allDayLocalTime?: string | null;
+  enabled?: number;
+}
+
+export interface UpdateTaskReminderInput {
+  endpointId?: number;
+  anchor?: ReminderAnchor;
+  offsetMinutes?: number;
+  allDayLocalTime?: string | null;
+  enabled?: number;
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+export function createTaskReminder(
+  db: Db,
+  userId: number,
+  input: CreateTaskReminderInput,
+): TaskReminder {
+  const now = timestamp();
+
+  return db
+    .insert(taskReminders)
+    .values({
+      userId,
+      taskId: input.taskId,
+      endpointId: input.endpointId,
+      anchor: input.anchor,
+      offsetMinutes: input.offsetMinutes,
+      allDayLocalTime: input.allDayLocalTime ?? null,
+      enabled: input.enabled ?? 1,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .get();
+}
+
+export function getTaskReminder(
+  db: Db,
+  userId: number,
+  id: number,
+): TaskReminder | null {
+  const row = db
+    .select()
+    .from(taskReminders)
+    .where(and(eq(taskReminders.userId, userId), eq(taskReminders.id, id)))
+    .get();
+
+  return row ?? null;
+}
+
+export function listTaskReminders(
+  db: Db,
+  userId: number,
+  taskId: number,
+): TaskReminder[] {
+  return db
+    .select()
+    .from(taskReminders)
+    .where(
+      and(eq(taskReminders.userId, userId), eq(taskReminders.taskId, taskId)),
+    )
+    .all();
+}
+
+export function updateTaskReminder(
+  db: Db,
+  userId: number,
+  id: number,
+  input: UpdateTaskReminderInput,
+): TaskReminder | null {
+  const existing = getTaskReminder(db, userId, id);
+  if (!existing) return null;
+
+  return db
+    .update(taskReminders)
+    .set({
+      endpointId: input.endpointId ?? existing.endpointId,
+      anchor: input.anchor ?? existing.anchor,
+      offsetMinutes: input.offsetMinutes ?? existing.offsetMinutes,
+      allDayLocalTime:
+        input.allDayLocalTime === undefined
+          ? existing.allDayLocalTime
+          : input.allDayLocalTime,
+      enabled: input.enabled ?? existing.enabled,
+      updatedAt: timestamp(),
+    })
+    .where(eq(taskReminders.id, existing.id))
+    .returning()
+    .get();
+}
+
+export function deleteTaskReminder(
+  db: Db,
+  userId: number,
+  id: number,
+): boolean {
+  const result = db
+    .delete(taskReminders)
+    .where(and(eq(taskReminders.userId, userId), eq(taskReminders.id, id)))
+    .run();
+
+  return result.changes > 0;
+}
+
+export function copyTaskReminders(
+  db: Db,
+  userId: number,
+  fromTaskId: number,
+  toTaskId: number,
+): TaskReminder[] {
+  const source = listTaskReminders(db, userId, fromTaskId);
+
+  return source.map((reminder) =>
+    createTaskReminder(db, userId, {
+      taskId: toTaskId,
+      endpointId: reminder.endpointId,
+      anchor: reminder.anchor,
+      offsetMinutes: reminder.offsetMinutes,
+      allDayLocalTime: reminder.allDayLocalTime,
+      enabled: reminder.enabled,
+    }),
+  );
+}

--- a/src/core/reminders/schedule.ts
+++ b/src/core/reminders/schedule.ts
@@ -1,0 +1,130 @@
+import type { Task, TaskStatus } from "../types";
+import type { ReminderAnchor } from "./types";
+
+export interface ReminderScheduleInput {
+  task: Pick<Task, "due" | "startAt" | "allDay" | "timezone" | "status">;
+  anchor: ReminderAnchor;
+  offsetMinutes: number;
+  allDayLocalTime?: string | null;
+  defaultAllDayLocalTime: string;
+  userTimezone: string;
+}
+
+function isValidTimeZone(value: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidLocalTime(value: string): boolean {
+  return /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(value);
+}
+
+function getAnchorIso(
+  task: Pick<Task, "due" | "startAt">,
+  anchor: ReminderAnchor,
+): string | null {
+  return anchor === "due" ? task.due : task.startAt;
+}
+
+function getDatePart(iso: string): string | null {
+  const match = iso.match(/^(\d{4}-\d{2}-\d{2})T/);
+  return match ? match[1] : null;
+}
+
+function getTimeZoneOffsetMs(date: Date, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const parts = Object.fromEntries(
+    formatter
+      .formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+
+  return asUtc - date.getTime();
+}
+
+function zonedDateTimeToUtc(
+  datePart: string,
+  timePart: string,
+  timeZone: string,
+): Date | null {
+  if (!isValidLocalTime(timePart) || !isValidTimeZone(timeZone)) {
+    return null;
+  }
+
+  const [year, month, day] = datePart.split("-").map(Number);
+  const [hour, minute] = timePart.split(":").map(Number);
+  const guess = new Date(Date.UTC(year, month - 1, day, hour, minute, 0, 0));
+  const offset = getTimeZoneOffsetMs(guess, timeZone);
+  const candidate = new Date(guess.getTime() - offset);
+  const correctedOffset = getTimeZoneOffsetMs(candidate, timeZone);
+
+  if (offset === correctedOffset) {
+    return candidate;
+  }
+
+  return new Date(guess.getTime() - correctedOffset);
+}
+
+export function shouldSuppressTaskReminders(status: TaskStatus): boolean {
+  return status === "done" || status === "cancelled";
+}
+
+export function resolveReminderBaseTime(
+  input: ReminderScheduleInput,
+): Date | null {
+  const anchorIso = getAnchorIso(input.task, input.anchor);
+  if (!anchorIso) return null;
+
+  if (input.task.allDay === 1) {
+    const datePart = getDatePart(anchorIso);
+    if (!datePart) return null;
+
+    const preferredTime = input.allDayLocalTime ?? input.defaultAllDayLocalTime;
+    if (!isValidLocalTime(preferredTime)) return null;
+
+    const preferredZone =
+      input.task.timezone && isValidTimeZone(input.task.timezone)
+        ? input.task.timezone
+        : input.userTimezone;
+
+    return zonedDateTimeToUtc(datePart, preferredTime, preferredZone);
+  }
+
+  const date = new Date(anchorIso);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function resolveReminderSendTime(
+  input: ReminderScheduleInput,
+): Date | null {
+  if (shouldSuppressTaskReminders(input.task.status)) return null;
+
+  const base = resolveReminderBaseTime(input);
+  if (!base) return null;
+
+  return new Date(base.getTime() + input.offsetMinutes * 60_000);
+}

--- a/src/core/reminders/types.ts
+++ b/src/core/reminders/types.ts
@@ -1,0 +1,82 @@
+import type {
+  reminderDeliveries,
+  reminderEndpoints,
+  taskReminders,
+} from "@/db/schema";
+
+export const REMINDER_CHANNELS = [
+  "sms",
+  "signal",
+  "telegram",
+  "discord",
+  "slack",
+] as const;
+export type ReminderChannel = (typeof REMINDER_CHANNELS)[number];
+
+export const REMINDER_ADAPTER_KEYS = [
+  "sms.twilio",
+  "signal.signal_cli",
+  "telegram.bot_api",
+  "discord.webhook",
+  "slack.webhook",
+] as const;
+export type ReminderAdapterKey = (typeof REMINDER_ADAPTER_KEYS)[number];
+
+export const REMINDER_CONFIG_SCOPES = ["system", "user", "none"] as const;
+export type ReminderConfigScope = (typeof REMINDER_CONFIG_SCOPES)[number];
+
+export const REMINDER_ANCHORS = ["due", "start"] as const;
+export type ReminderAnchor = (typeof REMINDER_ANCHORS)[number];
+
+export const REMINDER_TEST_STATUSES = ["ok", "failed"] as const;
+export type ReminderTestStatus = (typeof REMINDER_TEST_STATUSES)[number];
+
+export const REMINDER_DELIVERY_STATUSES = [
+  "pending",
+  "sending",
+  "sent",
+  "failed",
+  "dead",
+  "suppressed",
+] as const;
+export type ReminderDeliveryStatus =
+  (typeof REMINDER_DELIVERY_STATUSES)[number];
+
+export interface ReminderAdapterCapabilities {
+  supportsDeliveryStatus: boolean;
+  supportsRichText: boolean;
+  supportsTestSend: boolean;
+  beta: boolean;
+}
+
+export interface ReminderAdapterManifest {
+  key: ReminderAdapterKey;
+  channel: ReminderChannel;
+  displayName: string;
+  configScope: ReminderConfigScope;
+  capabilities: ReminderAdapterCapabilities;
+}
+
+export type ReminderEndpoint = typeof reminderEndpoints.$inferSelect;
+export type TaskReminder = typeof taskReminders.$inferSelect;
+export type ReminderDelivery = typeof reminderDeliveries.$inferSelect;
+
+export function isReminderAdapterKey(
+  value: string,
+): value is ReminderAdapterKey {
+  return REMINDER_ADAPTER_KEYS.includes(value as ReminderAdapterKey);
+}
+
+export function isReminderChannel(value: string): value is ReminderChannel {
+  return REMINDER_CHANNELS.includes(value as ReminderChannel);
+}
+
+export function isReminderAnchor(value: string): value is ReminderAnchor {
+  return REMINDER_ANCHORS.includes(value as ReminderAnchor);
+}
+
+export function isReminderDeliveryStatus(
+  value: string,
+): value is ReminderDeliveryStatus {
+  return REMINDER_DELIVERY_STATUSES.includes(value as ReminderDeliveryStatus);
+}

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gte, inArray, lte } from "drizzle-orm";
 import { tasks } from "@/db/schema";
 import { updateBlockedStatus } from "./dag";
 import { getNextTaskData } from "./recurrence";
+import { copyTaskReminders } from "./reminders/rules";
 import type {
   CreateTaskInput,
   Db,
@@ -148,6 +149,7 @@ export function completeTask(
     const nextData = getNextTaskData(task);
     if (nextData) {
       const spawned = createTask(db, userId, nextData);
+      copyTaskReminders(db, userId, task.id, spawned.id);
       spawnedTaskId = spawned.id;
     }
   }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -122,6 +122,95 @@ export const userSettings = sqliteTable("user_settings", {
   settings: text("settings").notNull(),
 });
 
+export const reminderEndpoints = sqliteTable("reminder_endpoints", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  adapterKey: text("adapter_key", {
+    enum: [
+      "sms.twilio",
+      "signal.signal_cli",
+      "telegram.bot_api",
+      "discord.webhook",
+      "slack.webhook",
+    ],
+  }).notNull(),
+  label: text("label").notNull(),
+  encryptedTarget: text("encrypted_target").notNull(),
+  metadata: text("metadata"),
+  enabled: integer("enabled").notNull().default(1),
+  lastTestAt: text("last_test_at"),
+  lastTestStatus: text("last_test_status", { enum: ["ok", "failed"] }),
+  lastTestError: text("last_test_error"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const taskReminders = sqliteTable("task_reminders", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  taskId: integer("task_id")
+    .notNull()
+    .references(() => tasks.id, { onDelete: "cascade" }),
+  endpointId: integer("endpoint_id")
+    .notNull()
+    .references(() => reminderEndpoints.id, { onDelete: "cascade" }),
+  anchor: text("anchor", { enum: ["due", "start"] }).notNull(),
+  offsetMinutes: integer("offset_minutes").notNull(),
+  allDayLocalTime: text("all_day_local_time"),
+  enabled: integer("enabled").notNull().default(1),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const reminderDeliveries = sqliteTable(
+  "reminder_deliveries",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    taskId: integer("task_id")
+      .notNull()
+      .references(() => tasks.id, { onDelete: "cascade" }),
+    taskReminderId: integer("task_reminder_id")
+      .notNull()
+      .references(() => taskReminders.id, { onDelete: "cascade" }),
+    endpointId: integer("endpoint_id")
+      .notNull()
+      .references(() => reminderEndpoints.id, { onDelete: "cascade" }),
+    adapterKey: text("adapter_key", {
+      enum: [
+        "sms.twilio",
+        "signal.signal_cli",
+        "telegram.bot_api",
+        "discord.webhook",
+        "slack.webhook",
+      ],
+    }).notNull(),
+    dedupeKey: text("dedupe_key").notNull(),
+    scheduledFor: text("scheduled_for").notNull(),
+    status: text("status", {
+      enum: ["pending", "sending", "sent", "failed", "dead", "suppressed"],
+    })
+      .notNull()
+      .default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    nextAttemptAt: text("next_attempt_at"),
+    providerMessageId: text("provider_message_id"),
+    renderedBody: text("rendered_body"),
+    error: text("error"),
+    lastAttemptAt: text("last_attempt_at"),
+    sentAt: text("sent_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => [unique().on(t.dedupeKey)],
+);
+
 export const inviteLinks = sqliteTable("invite_links", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   token: text("token").notNull().unique(),

--- a/tests/core/reminders/endpoints.test.ts
+++ b/tests/core/reminders/endpoints.test.ts
@@ -1,0 +1,197 @@
+import { randomBytes } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createReminderEndpoint,
+  deleteReminderEndpoint,
+  getReminderEndpoint,
+  listReminderEndpoints,
+  setReminderEndpointTestResult,
+  updateReminderEndpoint,
+} from "@/core/reminders/endpoints";
+import type { Db } from "@/core/types";
+import { reminderEndpoints } from "@/db/schema";
+import { createTestDb, createTestUser } from "../../helpers";
+
+const TEST_KEY = randomBytes(32).toString("hex");
+
+let db: Db;
+let userId: number;
+
+beforeEach(() => {
+  vi.stubEnv("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+  db = createTestDb();
+  userId = createTestUser(db).id;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("createReminderEndpoint", () => {
+  it("creates an endpoint with decrypted target in the return value", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms main",
+      target: "+15125501381",
+      metadata: { purpose: "manual-test" },
+    });
+
+    expect(endpoint.id).toBe(1);
+    expect(endpoint.adapterKey).toBe("sms.twilio");
+    expect(endpoint.label).toBe("sms main");
+    expect(endpoint.target).toBe("+15125501381");
+    expect(endpoint.metadata).toEqual({ purpose: "manual-test" });
+    expect(endpoint.enabled).toBe(1);
+  });
+
+  it("stores the endpoint target encrypted at rest", () => {
+    createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "telegram",
+      target: "123456789",
+    });
+
+    const raw = db
+      .select()
+      .from(reminderEndpoints)
+      .where(eq(reminderEndpoints.userId, userId))
+      .get();
+
+    expect(raw).not.toBeNull();
+    expect(raw?.encryptedTarget).not.toContain("123456789");
+    expect(raw?.encryptedTarget).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+  });
+});
+
+describe("getReminderEndpoint / listReminderEndpoints", () => {
+  it("returns null for nonexistent endpoint", () => {
+    expect(getReminderEndpoint(db, userId, 1)).toBeNull();
+  });
+
+  it("does not return another user's endpoint", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "slack.webhook",
+      label: "slack",
+      target: "https://hooks.slack.test/a",
+    });
+    const otherUser = createTestUser(db, "other-user");
+
+    expect(getReminderEndpoint(db, otherUser.id, endpoint.id)).toBeNull();
+  });
+
+  it("lists only the current user's endpoints", () => {
+    createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms",
+      target: "+15125501381",
+    });
+
+    const otherUser = createTestUser(db, "other-user");
+    createReminderEndpoint(db, otherUser.id, {
+      adapterKey: "telegram.bot_api",
+      label: "telegram",
+      target: "42",
+    });
+
+    const list = listReminderEndpoints(db, userId);
+    expect(list).toHaveLength(1);
+    expect(list[0].label).toBe("sms");
+  });
+});
+
+describe("updateReminderEndpoint", () => {
+  it("updates label, target, metadata, and enabled state", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "discord.webhook",
+      label: "discord",
+      target: "https://discord.test/old",
+      metadata: { channel: "ops" },
+    });
+
+    const updated = updateReminderEndpoint(db, userId, endpoint.id, {
+      label: "discord updated",
+      target: "https://discord.test/new",
+      metadata: { channel: "alerts" },
+      enabled: 0,
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.label).toBe("discord updated");
+    expect(updated?.target).toBe("https://discord.test/new");
+    expect(updated?.metadata).toEqual({ channel: "alerts" });
+    expect(updated?.enabled).toBe(0);
+  });
+
+  it("can clear metadata", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "slack.webhook",
+      label: "slack",
+      target: "https://hooks.slack.test/a",
+      metadata: { room: "private" },
+    });
+
+    const updated = updateReminderEndpoint(db, userId, endpoint.id, {
+      metadata: null,
+    });
+
+    expect(updated?.metadata).toBeNull();
+  });
+});
+
+describe("setReminderEndpointTestResult", () => {
+  it("records successful test state", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "telegram",
+      target: "123",
+    });
+
+    const updated = setReminderEndpointTestResult(
+      db,
+      userId,
+      endpoint.id,
+      "ok",
+    );
+
+    expect(updated?.lastTestStatus).toBe("ok");
+    expect(updated?.lastTestAt).toBeTruthy();
+    expect(updated?.lastTestError).toBeNull();
+  });
+
+  it("records failed test state", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "signal.signal_cli",
+      label: "signal",
+      target: "+15555550123",
+    });
+
+    const updated = setReminderEndpointTestResult(
+      db,
+      userId,
+      endpoint.id,
+      "failed",
+      "unreachable",
+    );
+
+    expect(updated?.lastTestStatus).toBe("failed");
+    expect(updated?.lastTestError).toBe("unreachable");
+  });
+});
+
+describe("deleteReminderEndpoint", () => {
+  it("deletes an endpoint", () => {
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms",
+      target: "+15125501381",
+    });
+
+    expect(deleteReminderEndpoint(db, userId, endpoint.id)).toBe(true);
+    expect(getReminderEndpoint(db, userId, endpoint.id)).toBeNull();
+  });
+
+  it("returns false for nonexistent endpoint", () => {
+    expect(deleteReminderEndpoint(db, userId, 999)).toBe(false);
+  });
+});

--- a/tests/core/reminders/registry.test.ts
+++ b/tests/core/reminders/registry.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  getReminderAdapter,
+  listReminderAdapters,
+} from "@/core/reminders/registry";
+import {
+  isReminderAdapterKey,
+  isReminderAnchor,
+  isReminderChannel,
+  isReminderDeliveryStatus,
+  REMINDER_ADAPTER_KEYS,
+  REMINDER_ANCHORS,
+  REMINDER_CHANNELS,
+  REMINDER_DELIVERY_STATUSES,
+} from "@/core/reminders/types";
+
+describe("reminder type guards", () => {
+  it("accepts known adapter keys", () => {
+    for (const key of REMINDER_ADAPTER_KEYS) {
+      expect(isReminderAdapterKey(key)).toBe(true);
+    }
+    expect(isReminderAdapterKey("sms.unknown")).toBe(false);
+  });
+
+  it("accepts known channels", () => {
+    for (const channel of REMINDER_CHANNELS) {
+      expect(isReminderChannel(channel)).toBe(true);
+    }
+    expect(isReminderChannel("email")).toBe(false);
+  });
+
+  it("accepts known anchors", () => {
+    for (const anchor of REMINDER_ANCHORS) {
+      expect(isReminderAnchor(anchor)).toBe(true);
+    }
+    expect(isReminderAnchor("custom")).toBe(false);
+  });
+
+  it("accepts known delivery statuses", () => {
+    for (const status of REMINDER_DELIVERY_STATUSES) {
+      expect(isReminderDeliveryStatus(status)).toBe(true);
+    }
+    expect(isReminderDeliveryStatus("queued")).toBe(false);
+  });
+});
+
+describe("reminder adapter registry", () => {
+  it("lists all supported adapters", () => {
+    const manifests = listReminderAdapters();
+
+    expect(manifests.map((manifest) => manifest.key)).toEqual([
+      ...REMINDER_ADAPTER_KEYS,
+    ]);
+  });
+
+  it("returns adapter metadata by key", () => {
+    const signal = getReminderAdapter("signal.signal_cli");
+
+    expect(signal).not.toBeNull();
+    expect(signal?.channel).toBe("signal");
+    expect(signal?.configScope).toBe("system");
+    expect(signal?.capabilities.beta).toBe(true);
+  });
+
+  it("returns null for unknown adapters", () => {
+    expect(getReminderAdapter("sms.telnyx")).toBeNull();
+  });
+
+  it("returns defensive copies", () => {
+    const manifests = listReminderAdapters();
+    manifests[0].displayName = "mutated";
+
+    const fresh = getReminderAdapter("sms.twilio");
+    expect(fresh?.displayName).toBe("Twilio SMS");
+  });
+});

--- a/tests/core/reminders/rules.test.ts
+++ b/tests/core/reminders/rules.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createReminderEndpoint } from "@/core/reminders/endpoints";
+import {
+  copyTaskReminders,
+  createTaskReminder,
+  deleteTaskReminder,
+  getTaskReminder,
+  listTaskReminders,
+  updateTaskReminder,
+} from "@/core/reminders/rules";
+import { completeTask, createTask } from "@/core/task";
+import type { Db } from "@/core/types";
+import { createTestDb, createTestUser } from "../../helpers";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+let db: Db;
+let userId: number;
+
+beforeEach(() => {
+  vi.stubEnv("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+  db = createTestDb();
+  userId = createTestUser(db).id;
+});
+
+describe("task reminder rules", () => {
+  it("creates and lists task reminders", () => {
+    const task = createTask(db, userId, { description: "Pay rent" });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms",
+      target: "+15125501381",
+    });
+
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    expect(reminder.taskId).toBe(task.id);
+    expect(reminder.endpointId).toBe(endpoint.id);
+    expect(listTaskReminders(db, userId, task.id)).toHaveLength(1);
+  });
+
+  it("updates a reminder rule", () => {
+    const task = createTask(db, userId, { description: "Review PR" });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "telegram",
+      target: "1234",
+    });
+
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -30,
+    });
+
+    const updated = updateTaskReminder(db, userId, reminder.id, {
+      anchor: "start",
+      offsetMinutes: 15,
+      allDayLocalTime: "09:30",
+      enabled: 0,
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.anchor).toBe("start");
+    expect(updated?.offsetMinutes).toBe(15);
+    expect(updated?.allDayLocalTime).toBe("09:30");
+    expect(updated?.enabled).toBe(0);
+  });
+
+  it("deletes a reminder rule", () => {
+    const task = createTask(db, userId, { description: "Doctor call" });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "slack.webhook",
+      label: "slack",
+      target: "https://hooks.slack.test/a",
+    });
+
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: 0,
+    });
+
+    expect(deleteTaskReminder(db, userId, reminder.id)).toBe(true);
+    expect(getTaskReminder(db, userId, reminder.id)).toBeNull();
+  });
+
+  it("copies reminder rules from one task to another", () => {
+    const source = createTask(db, userId, { description: "Source task" });
+    const target = createTask(db, userId, { description: "Target task" });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "discord.webhook",
+      label: "discord",
+      target: "https://discord.test/a",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: source.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -60,
+      allDayLocalTime: "08:00",
+    });
+
+    const copied = copyTaskReminders(db, userId, source.id, target.id);
+
+    expect(copied).toHaveLength(1);
+    expect(copied[0].taskId).toBe(target.id);
+    expect(copied[0].endpointId).toBe(endpoint.id);
+    expect(copied[0].offsetMinutes).toBe(-60);
+    expect(copied[0].allDayLocalTime).toBe("08:00");
+  });
+
+  it("copies reminder rules forward when recurring tasks spawn", () => {
+    const recurring = createTask(db, userId, {
+      description: "Weekly review",
+      due: "2026-03-22T09:00:00.000Z",
+      recurrence: "FREQ=WEEKLY",
+      recurMode: "scheduled",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms",
+      target: "+15125501381",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: recurring.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    const result = completeTask(db, userId, recurring.id);
+
+    expect(result.spawnedTaskId).not.toBeNull();
+    const spawnedReminders = listTaskReminders(
+      db,
+      userId,
+      result.spawnedTaskId as number,
+    );
+    expect(spawnedReminders).toHaveLength(1);
+    expect(spawnedReminders[0].endpointId).toBe(endpoint.id);
+    expect(spawnedReminders[0].offsetMinutes).toBe(-10);
+  });
+
+  it("does not copy reminders when no recurring task is spawned", () => {
+    const task = createTask(db, userId, { description: "One-off" });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "telegram",
+      target: "1234",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: 0,
+    });
+
+    const result = completeTask(db, userId, task.id);
+
+    expect(result.spawnedTaskId).toBeNull();
+  });
+});

--- a/tests/core/reminders/schedule.test.ts
+++ b/tests/core/reminders/schedule.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveReminderBaseTime,
+  resolveReminderSendTime,
+  shouldSuppressTaskReminders,
+} from "@/core/reminders/schedule";
+
+describe("shouldSuppressTaskReminders", () => {
+  it("suppresses reminders for done and cancelled tasks", () => {
+    expect(shouldSuppressTaskReminders("done")).toBe(true);
+    expect(shouldSuppressTaskReminders("cancelled")).toBe(true);
+  });
+
+  it("allows reminders for active task states", () => {
+    expect(shouldSuppressTaskReminders("pending")).toBe(false);
+    expect(shouldSuppressTaskReminders("wip")).toBe(false);
+    expect(shouldSuppressTaskReminders("blocked")).toBe(false);
+  });
+});
+
+describe("resolveReminderBaseTime", () => {
+  it("uses due time for timed tasks", () => {
+    const base = resolveReminderBaseTime({
+      task: {
+        due: "2026-04-06T15:30:00.000Z",
+        startAt: null,
+        allDay: 0,
+        timezone: null,
+        status: "pending",
+      },
+      anchor: "due",
+      offsetMinutes: 0,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(base?.toISOString()).toBe("2026-04-06T15:30:00.000Z");
+  });
+
+  it("uses start time for timed tasks", () => {
+    const base = resolveReminderBaseTime({
+      task: {
+        due: null,
+        startAt: "2026-04-06T14:00:00.000Z",
+        allDay: 0,
+        timezone: null,
+        status: "pending",
+      },
+      anchor: "start",
+      offsetMinutes: 0,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(base?.toISOString()).toBe("2026-04-06T14:00:00.000Z");
+  });
+
+  it("uses the task timezone for all-day tasks", () => {
+    const base = resolveReminderBaseTime({
+      task: {
+        due: "2026-03-22T00:00:00.000Z",
+        startAt: null,
+        allDay: 1,
+        timezone: "America/Chicago",
+        status: "pending",
+      },
+      anchor: "due",
+      offsetMinutes: 0,
+      allDayLocalTime: "09:00",
+      defaultAllDayLocalTime: "08:00",
+      userTimezone: "UTC",
+    });
+
+    expect(base?.toISOString()).toBe("2026-03-22T14:00:00.000Z");
+  });
+
+  it("falls back to the user timezone for all-day tasks", () => {
+    const base = resolveReminderBaseTime({
+      task: {
+        due: "2026-06-15T00:00:00.000Z",
+        startAt: null,
+        allDay: 1,
+        timezone: null,
+        status: "pending",
+      },
+      anchor: "due",
+      offsetMinutes: 0,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "America/New_York",
+    });
+
+    expect(base?.toISOString()).toBe("2026-06-15T13:00:00.000Z");
+  });
+
+  it("returns null when the anchor does not exist", () => {
+    const base = resolveReminderBaseTime({
+      task: {
+        due: null,
+        startAt: null,
+        allDay: 0,
+        timezone: null,
+        status: "pending",
+      },
+      anchor: "due",
+      offsetMinutes: 0,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(base).toBeNull();
+  });
+
+  it("returns null for invalid all-day local time", () => {
+    const base = resolveReminderBaseTime({
+      task: {
+        due: "2026-06-15T00:00:00.000Z",
+        startAt: null,
+        allDay: 1,
+        timezone: "UTC",
+        status: "pending",
+      },
+      anchor: "due",
+      offsetMinutes: 0,
+      allDayLocalTime: "25:00",
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(base).toBeNull();
+  });
+});
+
+describe("resolveReminderSendTime", () => {
+  it("applies negative offsets", () => {
+    const sendAt = resolveReminderSendTime({
+      task: {
+        due: "2026-04-06T15:30:00.000Z",
+        startAt: null,
+        allDay: 0,
+        timezone: null,
+        status: "pending",
+      },
+      anchor: "due",
+      offsetMinutes: -10,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(sendAt?.toISOString()).toBe("2026-04-06T15:20:00.000Z");
+  });
+
+  it("applies positive offsets", () => {
+    const sendAt = resolveReminderSendTime({
+      task: {
+        due: null,
+        startAt: "2026-04-06T14:00:00.000Z",
+        allDay: 0,
+        timezone: null,
+        status: "pending",
+      },
+      anchor: "start",
+      offsetMinutes: 60,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(sendAt?.toISOString()).toBe("2026-04-06T15:00:00.000Z");
+  });
+
+  it("returns null for suppressed task states", () => {
+    const sendAt = resolveReminderSendTime({
+      task: {
+        due: "2026-04-06T15:30:00.000Z",
+        startAt: null,
+        allDay: 0,
+        timezone: null,
+        status: "done",
+      },
+      anchor: "due",
+      offsetMinutes: 0,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: "UTC",
+    });
+
+    expect(sendAt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add reminder schema for endpoints, task reminder rules, and durable delivery records
- add reminder core modules for adapter registry, encrypted endpoints, scheduling, and task reminder rules
- preserve reminder rules when recurring tasks spawn their next instance
- add focused reminder tests and the migration/journal entry for the new schema

Related to #189, #191, #192, #194, #195.

#### Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `./scripts/ci.sh` currently fails on pre-existing Biome issues in `cli/dist/delta.js`