### PR TITLE
feat(reminders): add delivery queue primitives

### DIFF
--- a/src/core/reminders/deliveries.ts
+++ b/src/core/reminders/deliveries.ts
@@ -1,0 +1,307 @@
+import { and, asc, eq, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import {
+  reminderDeliveries,
+  reminderEndpoints,
+  taskReminders,
+  tasks,
+} from "@/db/schema";
+import type { Db, Task } from "../types";
+import { resolveReminderSendTime } from "./schedule";
+import type { ReminderDelivery } from "./types";
+
+export const MAX_REMINDER_ATTEMPTS = 5;
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+export function buildReminderDedupeKey(input: {
+  userId: number;
+  taskId: number;
+  taskReminderId: number;
+  endpointId: number;
+  scheduledFor: string;
+}): string {
+  return [
+    input.userId,
+    input.taskId,
+    input.taskReminderId,
+    input.endpointId,
+    input.scheduledFor,
+  ].join(":");
+}
+
+export function computeReminderRetryDelayMinutes(attempts: number): number {
+  if (attempts <= 1) return 1;
+  if (attempts === 2) return 5;
+  if (attempts === 3) return 15;
+  return 60;
+}
+
+export function computeReminderRetryTime(
+  attemptedAt: string,
+  attempts: number,
+): string {
+  const delayMs = computeReminderRetryDelayMinutes(attempts) * 60_000;
+  return new Date(new Date(attemptedAt).getTime() + delayMs).toISOString();
+}
+
+export function getReminderDelivery(
+  db: Db,
+  id: number,
+): ReminderDelivery | null {
+  const row = db
+    .select()
+    .from(reminderDeliveries)
+    .where(eq(reminderDeliveries.id, id))
+    .get();
+
+  return row ?? null;
+}
+
+export function enqueueReminderDelivery(
+  db: Db,
+  input: {
+    userId: number;
+    taskId: number;
+    taskReminderId: number;
+    endpointId: number;
+    adapterKey: ReminderDelivery["adapterKey"];
+    scheduledFor: string;
+  },
+): ReminderDelivery {
+  const dedupeKey = buildReminderDedupeKey({
+    userId: input.userId,
+    taskId: input.taskId,
+    taskReminderId: input.taskReminderId,
+    endpointId: input.endpointId,
+    scheduledFor: input.scheduledFor,
+  });
+  const now = timestamp();
+
+  db.insert(reminderDeliveries)
+    .values({
+      userId: input.userId,
+      taskId: input.taskId,
+      taskReminderId: input.taskReminderId,
+      endpointId: input.endpointId,
+      adapterKey: input.adapterKey,
+      dedupeKey,
+      scheduledFor: input.scheduledFor,
+      status: "pending",
+      attempts: 0,
+      nextAttemptAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing({ target: reminderDeliveries.dedupeKey })
+    .run();
+
+  const row = db
+    .select()
+    .from(reminderDeliveries)
+    .where(eq(reminderDeliveries.dedupeKey, dedupeKey))
+    .get();
+
+  if (!row) {
+    throw new Error(`Failed to enqueue reminder delivery ${dedupeKey}`);
+  }
+
+  return row;
+}
+
+export function listDispatchableReminderDeliveries(
+  db: Db,
+  nowIso: string,
+  limit = 50,
+): ReminderDelivery[] {
+  return db
+    .select()
+    .from(reminderDeliveries)
+    .where(
+      and(
+        inArray(reminderDeliveries.status, ["pending", "failed"]),
+        lte(reminderDeliveries.scheduledFor, nowIso),
+        or(
+          isNull(reminderDeliveries.nextAttemptAt),
+          lte(reminderDeliveries.nextAttemptAt, nowIso),
+        ),
+      ),
+    )
+    .orderBy(asc(reminderDeliveries.scheduledFor), asc(reminderDeliveries.id))
+    .limit(limit)
+    .all();
+}
+
+export function claimReminderDelivery(
+  db: Db,
+  id: number,
+  nowIso: string,
+): ReminderDelivery | null {
+  const row = db
+    .update(reminderDeliveries)
+    .set({
+      status: "sending",
+      attempts: sql`${reminderDeliveries.attempts} + 1`,
+      lastAttemptAt: nowIso,
+      updatedAt: nowIso,
+    })
+    .where(
+      and(
+        eq(reminderDeliveries.id, id),
+        inArray(reminderDeliveries.status, ["pending", "failed"]),
+        lte(reminderDeliveries.scheduledFor, nowIso),
+        or(
+          isNull(reminderDeliveries.nextAttemptAt),
+          lte(reminderDeliveries.nextAttemptAt, nowIso),
+        ),
+      ),
+    )
+    .returning()
+    .get();
+
+  return row ?? null;
+}
+
+export function markReminderDeliverySent(
+  db: Db,
+  id: number,
+  input: {
+    providerMessageId?: string | null;
+    renderedBody?: string | null;
+  } = {},
+): ReminderDelivery | null {
+  const now = timestamp();
+  const row = db
+    .update(reminderDeliveries)
+    .set({
+      status: "sent",
+      providerMessageId: input.providerMessageId ?? null,
+      renderedBody: input.renderedBody ?? null,
+      sentAt: now,
+      nextAttemptAt: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(reminderDeliveries.id, id),
+        eq(reminderDeliveries.status, "sending"),
+      ),
+    )
+    .returning()
+    .get();
+
+  return row ?? null;
+}
+
+export function markReminderDeliveryFailed(
+  db: Db,
+  id: number,
+  error: string,
+  retryable = true,
+): ReminderDelivery | null {
+  const existing = getReminderDelivery(db, id);
+  if (!existing || existing.status !== "sending") return null;
+
+  const now = timestamp();
+  const attemptedAt = existing.lastAttemptAt ?? now;
+  const exhausted = !retryable || existing.attempts >= MAX_REMINDER_ATTEMPTS;
+
+  const row = db
+    .update(reminderDeliveries)
+    .set({
+      status: exhausted ? "dead" : "failed",
+      error,
+      nextAttemptAt: exhausted
+        ? null
+        : computeReminderRetryTime(attemptedAt, existing.attempts),
+      updatedAt: now,
+    })
+    .where(eq(reminderDeliveries.id, id))
+    .returning()
+    .get();
+
+  return row ?? null;
+}
+
+export function suppressPendingReminderDeliveriesForTask(
+  db: Db,
+  taskId: number,
+): number {
+  const result = db
+    .update(reminderDeliveries)
+    .set({
+      status: "suppressed",
+      nextAttemptAt: null,
+      updatedAt: timestamp(),
+    })
+    .where(
+      and(
+        eq(reminderDeliveries.taskId, taskId),
+        inArray(reminderDeliveries.status, ["pending", "failed"]),
+      ),
+    )
+    .run();
+
+  return result.changes;
+}
+
+export function enqueueDueReminderDeliveries(
+  db: Db,
+  input: {
+    nowIso: string;
+    userTimezoneResolver: (userId: number) => string;
+  },
+): ReminderDelivery[] {
+  const joined = db
+    .select({
+      reminder: taskReminders,
+      task: tasks,
+      endpoint: reminderEndpoints,
+    })
+    .from(taskReminders)
+    .innerJoin(tasks, eq(taskReminders.taskId, tasks.id))
+    .innerJoin(
+      reminderEndpoints,
+      eq(taskReminders.endpointId, reminderEndpoints.id),
+    )
+    .where(and(eq(taskReminders.enabled, 1), eq(reminderEndpoints.enabled, 1)))
+    .all();
+
+  const now = new Date(input.nowIso).getTime();
+  const enqueued: ReminderDelivery[] = [];
+
+  for (const row of joined) {
+    if (row.task.status === "done" || row.task.status === "cancelled") {
+      suppressPendingReminderDeliveriesForTask(db, row.task.id);
+      continue;
+    }
+
+    const sendAt = resolveReminderSendTime({
+      task: row.task as Pick<
+        Task,
+        "due" | "startAt" | "allDay" | "timezone" | "status"
+      >,
+      anchor: row.reminder.anchor,
+      offsetMinutes: row.reminder.offsetMinutes,
+      allDayLocalTime: row.reminder.allDayLocalTime,
+      defaultAllDayLocalTime: "09:00",
+      userTimezone: input.userTimezoneResolver(row.reminder.userId),
+    });
+
+    if (!sendAt || sendAt.getTime() > now) continue;
+
+    enqueued.push(
+      enqueueReminderDelivery(db, {
+        userId: row.reminder.userId,
+        taskId: row.task.id,
+        taskReminderId: row.reminder.id,
+        endpointId: row.endpoint.id,
+        adapterKey: row.endpoint.adapterKey,
+        scheduledFor: sendAt.toISOString(),
+      }),
+    );
+  }
+
+  return enqueued;
+}

--- a/tests/core/reminders/deliveries.test.ts
+++ b/tests/core/reminders/deliveries.test.ts
@@ -1,0 +1,401 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildReminderDedupeKey,
+  claimReminderDelivery,
+  computeReminderRetryDelayMinutes,
+  enqueueDueReminderDeliveries,
+  enqueueReminderDelivery,
+  getReminderDelivery,
+  listDispatchableReminderDeliveries,
+  MAX_REMINDER_ATTEMPTS,
+  markReminderDeliveryFailed,
+  markReminderDeliverySent,
+  suppressPendingReminderDeliveriesForTask,
+} from "@/core/reminders/deliveries";
+import { createReminderEndpoint } from "@/core/reminders/endpoints";
+import { createTaskReminder } from "@/core/reminders/rules";
+import { createTask, updateTask } from "@/core/task";
+import type { Db } from "@/core/types";
+import { createTestDb, createTestUser } from "../../helpers";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+let db: Db;
+let userId: number;
+
+function createDeliveryFixture(
+  adapterKey:
+    | "sms.twilio"
+    | "telegram.bot_api"
+    | "slack.webhook"
+    | "discord.webhook"
+    | "signal.signal_cli" = "sms.twilio",
+) {
+  const task = createTask(db, userId, {
+    description: `Task for ${adapterKey}`,
+    due: "2026-04-06T15:30:00.000Z",
+  });
+  const endpoint = createReminderEndpoint(db, userId, {
+    adapterKey,
+    label: adapterKey,
+    target:
+      adapterKey === "sms.twilio" || adapterKey === "signal.signal_cli"
+        ? "+15125501381"
+        : adapterKey === "telegram.bot_api"
+          ? "1234"
+          : `https://${adapterKey.replace(".", "-")}.test/hook`,
+  });
+  const reminder = createTaskReminder(db, userId, {
+    taskId: task.id,
+    endpointId: endpoint.id,
+    anchor: "due",
+    offsetMinutes: -10,
+  });
+
+  return { task, endpoint, reminder };
+}
+
+beforeEach(() => {
+  vi.stubEnv("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+  db = createTestDb();
+  userId = createTestUser(db).id;
+});
+
+describe("reminder delivery queue", () => {
+  it("builds stable dedupe keys", () => {
+    const key = buildReminderDedupeKey({
+      userId,
+      taskId: 1,
+      taskReminderId: 2,
+      endpointId: 3,
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    expect(key).toBe(`${userId}:1:2:3:2026-04-06T15:20:00.000Z`);
+  });
+
+  it("enqueues deliveries idempotently", () => {
+    const { task, endpoint, reminder } = createDeliveryFixture();
+
+    const first = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+    const second = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    expect(first.id).toBe(second.id);
+    expect(
+      listDispatchableReminderDeliveries(db, "2026-04-06T16:00:00.000Z"),
+    ).toHaveLength(1);
+  });
+
+  it("enqueues due reminder rules from tasks", () => {
+    const task = createTask(db, userId, {
+      description: "Pay rent",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms",
+      target: "+15125501381",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    const deliveries = enqueueDueReminderDeliveries(db, {
+      nowIso: "2026-04-06T15:25:00.000Z",
+      userTimezoneResolver: () => "UTC",
+    });
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].scheduledFor).toBe("2026-04-06T15:20:00.000Z");
+  });
+
+  it("does not enqueue future reminders", () => {
+    const task = createTask(db, userId, {
+      description: "Standup",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "telegram",
+      target: "1234",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    const deliveries = enqueueDueReminderDeliveries(db, {
+      nowIso: "2026-04-06T15:10:00.000Z",
+      userTimezoneResolver: () => "UTC",
+    });
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  it("suppresses pending deliveries for completed tasks", () => {
+    const task = createTask(db, userId, {
+      description: "Doctor call",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "sms",
+      target: "+15125501381",
+    });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: endpoint.adapterKey,
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    updateTask(db, task.id, { status: "done" });
+
+    enqueueDueReminderDeliveries(db, {
+      nowIso: "2026-04-06T15:25:00.000Z",
+      userTimezoneResolver: () => "UTC",
+    });
+
+    const updated = getReminderDelivery(db, delivery.id);
+    expect(updated?.status).toBe("suppressed");
+  });
+});
+
+describe("reminder delivery dispatch state", () => {
+  it("lists dispatchable pending and retryable failed deliveries", () => {
+    const pendingFixture = createDeliveryFixture("sms.twilio");
+    const pending = enqueueReminderDelivery(db, {
+      userId,
+      taskId: pendingFixture.task.id,
+      taskReminderId: pendingFixture.reminder.id,
+      endpointId: pendingFixture.endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    const failedFixture = createDeliveryFixture("telegram.bot_api");
+    const failed = enqueueReminderDelivery(db, {
+      userId,
+      taskId: failedFixture.task.id,
+      taskReminderId: failedFixture.reminder.id,
+      endpointId: failedFixture.endpoint.id,
+      adapterKey: "telegram.bot_api",
+      scheduledFor: "2026-04-06T15:00:00.000Z",
+    });
+
+    claimReminderDelivery(db, failed.id, "2026-04-06T15:30:00.000Z");
+    markReminderDeliveryFailed(db, failed.id, "temporary", true);
+
+    const ready = listDispatchableReminderDeliveries(
+      db,
+      "2026-04-06T15:35:01.000Z",
+    );
+
+    expect(ready.map((item) => item.id)).toContain(pending.id);
+    expect(ready.map((item) => item.id)).toContain(failed.id);
+  });
+
+  it("claims a delivery once and increments attempts", () => {
+    const { task, endpoint, reminder } = createDeliveryFixture();
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    const claimed = claimReminderDelivery(
+      db,
+      delivery.id,
+      "2026-04-06T15:25:00.000Z",
+    );
+    const secondClaim = claimReminderDelivery(
+      db,
+      delivery.id,
+      "2026-04-06T15:25:01.000Z",
+    );
+
+    expect(claimed?.status).toBe("sending");
+    expect(claimed?.attempts).toBe(1);
+    expect(secondClaim).toBeNull();
+  });
+
+  it("marks sending deliveries as sent", () => {
+    const { task, endpoint, reminder } = createDeliveryFixture();
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    claimReminderDelivery(db, delivery.id, "2026-04-06T15:25:00.000Z");
+    const sent = markReminderDeliverySent(db, delivery.id, {
+      providerMessageId: "msg_123",
+      renderedBody: "reminder text",
+    });
+
+    expect(sent?.status).toBe("sent");
+    expect(sent?.providerMessageId).toBe("msg_123");
+    expect(sent?.renderedBody).toBe("reminder text");
+    expect(sent?.sentAt).toBeTruthy();
+  });
+
+  it("marks retryable failures with a next attempt time", () => {
+    const { task, endpoint, reminder } = createDeliveryFixture();
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    claimReminderDelivery(db, delivery.id, "2026-04-06T15:25:00.000Z");
+    const failed = markReminderDeliveryFailed(
+      db,
+      delivery.id,
+      "temporary",
+      true,
+    );
+
+    expect(failed?.status).toBe("failed");
+    expect(failed?.nextAttemptAt).toBe("2026-04-06T15:26:00.000Z");
+  });
+
+  it("marks non-retryable failures as dead", () => {
+    const { task, endpoint, reminder } = createDeliveryFixture();
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    claimReminderDelivery(db, delivery.id, "2026-04-06T15:25:00.000Z");
+    const failed = markReminderDeliveryFailed(db, delivery.id, "fatal", false);
+
+    expect(failed?.status).toBe("dead");
+    expect(failed?.nextAttemptAt).toBeNull();
+  });
+
+  it("marks exhausted retry attempts as dead", () => {
+    const { task, endpoint, reminder } = createDeliveryFixture();
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    const claimTimes = [
+      "2026-04-06T15:25:00.000Z",
+      "2026-04-06T15:26:00.000Z",
+      "2026-04-06T15:31:00.000Z",
+      "2026-04-06T15:46:00.000Z",
+      "2026-04-06T16:46:00.000Z",
+    ];
+
+    for (let i = 0; i < MAX_REMINDER_ATTEMPTS; i++) {
+      claimReminderDelivery(db, delivery.id, claimTimes[i]);
+      const failed = markReminderDeliveryFailed(
+        db,
+        delivery.id,
+        "temporary",
+        true,
+      );
+      if (i < MAX_REMINDER_ATTEMPTS - 1) {
+        expect(failed?.status).toBe("failed");
+      } else {
+        expect(failed?.status).toBe("dead");
+      }
+    }
+  });
+
+  it("suppresses pending and failed deliveries for a task", () => {
+    const firstFixture = createDeliveryFixture("sms.twilio");
+    const pending = enqueueReminderDelivery(db, {
+      userId,
+      taskId: firstFixture.task.id,
+      taskReminderId: firstFixture.reminder.id,
+      endpointId: firstFixture.endpoint.id,
+      adapterKey: "sms.twilio",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+    const secondFixture = createDeliveryFixture("telegram.bot_api");
+    const failed = enqueueReminderDelivery(db, {
+      userId,
+      taskId: secondFixture.task.id,
+      taskReminderId: secondFixture.reminder.id,
+      endpointId: secondFixture.endpoint.id,
+      adapterKey: "telegram.bot_api",
+      scheduledFor: "2026-04-06T15:00:00.000Z",
+    });
+
+    claimReminderDelivery(db, failed.id, "2026-04-06T15:25:00.000Z");
+    markReminderDeliveryFailed(db, failed.id, "temporary", true);
+
+    const firstChanged = suppressPendingReminderDeliveriesForTask(
+      db,
+      firstFixture.task.id,
+    );
+    const secondChanged = suppressPendingReminderDeliveriesForTask(
+      db,
+      secondFixture.task.id,
+    );
+
+    expect(firstChanged).toBe(1);
+    expect(secondChanged).toBe(1);
+    expect(getReminderDelivery(db, pending.id)?.status).toBe("suppressed");
+    expect(getReminderDelivery(db, failed.id)?.status).toBe("suppressed");
+  });
+});
+
+describe("retry delay helpers", () => {
+  it("uses stepped retry delays", () => {
+    expect(computeReminderRetryDelayMinutes(1)).toBe(1);
+    expect(computeReminderRetryDelayMinutes(2)).toBe(5);
+    expect(computeReminderRetryDelayMinutes(3)).toBe(15);
+    expect(computeReminderRetryDelayMinutes(4)).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- add reminder delivery queue primitives with stable dedupe keys and idempotent enqueueing
- add dispatch state transitions for claim, send, fail, suppress, and retry/dead handling
- enqueue due task reminders from reminder rules with task completion suppression and retry/backoff coverage

#### Test plan
- [x] `nix develop . -c biome check --write src/core/reminders/deliveries.ts tests/core/reminders/deliveries.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/core/reminders/deliveries.test.ts tests/core/reminders/rules.test.ts tests/core/reminders/endpoints.test.ts tests/core/reminders/schedule.test.ts`
- [x] `pnpm test`