### PR TITLE
feat(reminders): add reminder API and worker

### DIFF
--- a/src/app/api/reminders/adapters/route.ts
+++ b/src/app/api/reminders/adapters/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { listReminderAdapters } from "@/core/reminders/registry";
+import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
+
+export async function GET(request: Request) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  return NextResponse.json(listReminderAdapters());
+}

--- a/src/app/api/reminders/endpoints/[id]/route.ts
+++ b/src/app/api/reminders/endpoints/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import {
+  deleteReminderEndpoint,
+  getReminderEndpoint,
+  updateReminderEndpoint,
+} from "@/core/reminders/endpoints";
+import { db } from "@/db";
+import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
+import { validateUpdateReminderEndpoint } from "@/lib/reminder-validation";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id } = await params;
+  const endpoint = getReminderEndpoint(db, user.id, Number(id));
+  if (!endpoint) {
+    return NextResponse.json(
+      { error: "Reminder endpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(endpoint);
+}
+
+export async function PATCH(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id } = await params;
+  const endpointId = Number(id);
+  const existing = getReminderEndpoint(db, user.id, endpointId);
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Reminder endpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  const body = await request.json();
+  const result = validateUpdateReminderEndpoint(body);
+  if (!result.success || !result.data) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.errors },
+      { status: 400 },
+    );
+  }
+
+  const endpoint = updateReminderEndpoint(db, user.id, endpointId, result.data);
+  if (!endpoint) {
+    return NextResponse.json(
+      { error: "Reminder endpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(endpoint);
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id } = await params;
+  const deleted = deleteReminderEndpoint(db, user.id, Number(id));
+  if (!deleted) {
+    return NextResponse.json(
+      { error: "Reminder endpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/reminders/endpoints/route.ts
+++ b/src/app/api/reminders/endpoints/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import {
+  createReminderEndpoint,
+  listReminderEndpoints,
+} from "@/core/reminders/endpoints";
+import { db } from "@/db";
+import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
+import { validateCreateReminderEndpoint } from "@/lib/reminder-validation";
+
+export async function GET(request: Request) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  return NextResponse.json(listReminderEndpoints(db, user.id));
+}
+
+export async function POST(request: Request) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const body = await request.json();
+  const result = validateCreateReminderEndpoint(body);
+
+  if (!result.success || !result.data) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.errors },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const endpoint = createReminderEndpoint(db, user.id, result.data);
+    return NextResponse.json(endpoint, { status: 201 });
+  } catch (e) {
+    const message =
+      e instanceof Error ? e.message : "Failed to create reminder endpoint";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/reminders/[reminderId]/route.ts
+++ b/src/app/api/tasks/[id]/reminders/[reminderId]/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { getReminderEndpoint } from "@/core/reminders/endpoints";
+import {
+  deleteTaskReminder,
+  getTaskReminder,
+  updateTaskReminder,
+} from "@/core/reminders/rules";
+import { getTask } from "@/core/task";
+import { db } from "@/db";
+import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
+import { validateUpdateTaskReminder } from "@/lib/reminder-validation";
+
+type Params = { params: Promise<{ id: string; reminderId: string }> };
+
+function taskNotFound() {
+  return NextResponse.json({ error: "Task not found" }, { status: 404 });
+}
+
+function reminderNotFound() {
+  return NextResponse.json(
+    { error: "Task reminder not found" },
+    { status: 404 },
+  );
+}
+
+function endpointNotFound() {
+  return NextResponse.json(
+    { error: "Reminder endpoint not found" },
+    { status: 404 },
+  );
+}
+
+export async function PATCH(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id, reminderId } = await params;
+  const taskId = Number(id);
+  const task = getTask(db, taskId);
+  if (!task || task.userId !== user.id) {
+    return taskNotFound();
+  }
+
+  const reminder = getTaskReminder(db, user.id, Number(reminderId));
+  if (!reminder || reminder.taskId !== taskId) {
+    return reminderNotFound();
+  }
+
+  const body = await request.json();
+  const result = validateUpdateTaskReminder(body);
+  if (!result.success || !result.data) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.errors },
+      { status: 400 },
+    );
+  }
+
+  if (result.data.endpointId !== undefined) {
+    const endpoint = getReminderEndpoint(db, user.id, result.data.endpointId);
+    if (!endpoint) {
+      return endpointNotFound();
+    }
+  }
+
+  const updated = updateTaskReminder(db, user.id, reminder.id, result.data);
+  if (!updated || updated.taskId !== taskId) {
+    return reminderNotFound();
+  }
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id, reminderId } = await params;
+  const taskId = Number(id);
+  const task = getTask(db, taskId);
+  if (!task || task.userId !== user.id) {
+    return taskNotFound();
+  }
+
+  const reminder = getTaskReminder(db, user.id, Number(reminderId));
+  if (!reminder || reminder.taskId !== taskId) {
+    return reminderNotFound();
+  }
+
+  const deleted = deleteTaskReminder(db, user.id, reminder.id);
+  if (!deleted) {
+    return reminderNotFound();
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/tasks/[id]/reminders/route.ts
+++ b/src/app/api/tasks/[id]/reminders/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { getReminderEndpoint } from "@/core/reminders/endpoints";
+import { createTaskReminder, listTaskReminders } from "@/core/reminders/rules";
+import { getTask } from "@/core/task";
+import { db } from "@/db";
+import { getAuthUserFromRequest, unauthorized } from "@/lib/auth-middleware";
+import { validateCreateTaskReminder } from "@/lib/reminder-validation";
+
+type Params = { params: Promise<{ id: string }> };
+
+function taskNotFound() {
+  return NextResponse.json({ error: "Task not found" }, { status: 404 });
+}
+
+function endpointNotFound() {
+  return NextResponse.json(
+    { error: "Reminder endpoint not found" },
+    { status: 404 },
+  );
+}
+
+export async function GET(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id } = await params;
+  const task = getTask(db, Number(id));
+  if (!task || task.userId !== user.id) {
+    return taskNotFound();
+  }
+
+  return NextResponse.json(listTaskReminders(db, user.id, task.id));
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const user = await getAuthUserFromRequest(request);
+  if (!user) return unauthorized();
+
+  const { id } = await params;
+  const taskId = Number(id);
+  const task = getTask(db, taskId);
+  if (!task || task.userId !== user.id) {
+    return taskNotFound();
+  }
+
+  const body = await request.json();
+  const result = validateCreateTaskReminder(body);
+  if (!result.success || !result.data) {
+    return NextResponse.json(
+      { error: "Validation failed", details: result.errors },
+      { status: 400 },
+    );
+  }
+
+  const endpoint = getReminderEndpoint(db, user.id, result.data.endpointId);
+  if (!endpoint) {
+    return endpointNotFound();
+  }
+
+  try {
+    const reminder = createTaskReminder(db, user.id, {
+      taskId,
+      endpointId: result.data.endpointId,
+      anchor: result.data.anchor,
+      offsetMinutes: result.data.offsetMinutes,
+      allDayLocalTime: result.data.allDayLocalTime,
+      enabled: result.data.enabled,
+    });
+    return NextResponse.json(reminder, { status: 201 });
+  } catch (e) {
+    const message =
+      e instanceof Error ? e.message : "Failed to create task reminder";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/core/reminders/worker.ts
+++ b/src/core/reminders/worker.ts
@@ -1,0 +1,53 @@
+import { type ScheduledTask, schedule } from "node-cron";
+import type { Db } from "../types";
+import { enqueueDueReminderDeliveries } from "./deliveries";
+import type { ReminderDelivery } from "./types";
+
+export const REMINDER_WORKER_CRON = "* * * * *";
+export const DEFAULT_REMINDER_TIMEZONE = "UTC";
+
+export interface ReminderWorkerRunResult {
+  nowIso: string;
+  enqueued: ReminderDelivery[];
+}
+
+let reminderJob: ScheduledTask | null = null;
+
+export function runReminderWorker(
+  db: Db,
+  input: {
+    nowIso?: string;
+    userTimezoneResolver?: (userId: number) => string;
+  } = {},
+): ReminderWorkerRunResult {
+  const nowIso = input.nowIso ?? new Date().toISOString();
+  const userTimezoneResolver =
+    input.userTimezoneResolver ?? (() => DEFAULT_REMINDER_TIMEZONE);
+
+  return {
+    nowIso,
+    enqueued: enqueueDueReminderDeliveries(db, {
+      nowIso,
+      userTimezoneResolver,
+    }),
+  };
+}
+
+export function startReminderWorker(db: Db): () => void {
+  stopReminderWorker();
+
+  reminderJob = schedule(REMINDER_WORKER_CRON, async () => {
+    try {
+      runReminderWorker(db);
+    } catch {}
+  });
+
+  return stopReminderWorker;
+}
+
+export function stopReminderWorker(): void {
+  if (!reminderJob) return;
+
+  reminderJob.stop();
+  reminderJob = null;
+}

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gte, inArray, lte } from "drizzle-orm";
 import { tasks } from "@/db/schema";
 import { updateBlockedStatus } from "./dag";
 import { getNextTaskData } from "./recurrence";
+import { suppressPendingReminderDeliveriesForTask } from "./reminders/deliveries";
 import { copyTaskReminders } from "./reminders/rules";
 import type {
   CreateTaskInput,
@@ -124,7 +125,7 @@ export function updateTask(db: Db, id: number, input: UpdateTaskInput): Task {
     input.status !== "cancelled" &&
     (existing.status === "done" || existing.status === "cancelled");
 
-  return db
+  const task = db
     .update(tasks)
     .set({
       ...input,
@@ -135,6 +136,12 @@ export function updateTask(db: Db, id: number, input: UpdateTaskInput): Task {
     .where(eq(tasks.id, id))
     .returning()
     .get();
+
+  if (isCompleting) {
+    suppressPendingReminderDeliveriesForTask(db, id);
+  }
+
+  return task;
 }
 
 export function completeTask(

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,9 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { startScheduler } = await import("@/core/automation");
+    const { startReminderWorker } = await import("@/core/reminders/worker");
     const { db } = await import("@/db");
     await startScheduler(db);
+    startReminderWorker(db);
   }
 }

--- a/src/lib/reminder-validation.ts
+++ b/src/lib/reminder-validation.ts
@@ -1,0 +1,344 @@
+import type {
+  CreateReminderEndpointInput,
+  UpdateReminderEndpointInput,
+} from "@/core/reminders/endpoints";
+import type {
+  CreateTaskReminderInput,
+  UpdateTaskReminderInput,
+} from "@/core/reminders/rules";
+import { isReminderAdapterKey, isReminderAnchor } from "@/core/reminders/types";
+
+interface ValidationError {
+  field: string;
+  message: string;
+}
+
+interface ValidationResult<T> {
+  success: boolean;
+  data?: T;
+  errors?: ValidationError[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitize(value: string): string {
+  return value.replace(/<[^>]*>/g, "");
+}
+
+function isValidFlag(value: unknown): value is 0 | 1 {
+  return value === 0 || value === 1;
+}
+
+function isValidAllDayLocalTime(value: string): boolean {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+}
+
+export function validateCreateReminderEndpoint(
+  body: unknown,
+): ValidationResult<CreateReminderEndpointInput> {
+  if (!isRecord(body)) {
+    return {
+      success: false,
+      errors: [{ field: "body", message: "Request body must be an object" }],
+    };
+  }
+
+  const errors: ValidationError[] = [];
+
+  if (
+    typeof body.adapterKey !== "string" ||
+    !isReminderAdapterKey(body.adapterKey)
+  ) {
+    errors.push({
+      field: "adapterKey",
+      message: "adapterKey must be a supported reminder adapter",
+    });
+  }
+
+  if (
+    typeof body.label !== "string" ||
+    sanitize(body.label).trim().length === 0
+  ) {
+    errors.push({
+      field: "label",
+      message: "label is required and must be a non-empty string",
+    });
+  }
+
+  if (typeof body.target !== "string" || body.target.trim().length === 0) {
+    errors.push({
+      field: "target",
+      message: "target is required and must be a non-empty string",
+    });
+  }
+
+  if (body.metadata !== undefined && !isRecord(body.metadata)) {
+    errors.push({
+      field: "metadata",
+      message: "metadata must be an object",
+    });
+  }
+
+  if (body.enabled !== undefined && !isValidFlag(body.enabled)) {
+    errors.push({
+      field: "enabled",
+      message: "enabled must be 0 or 1",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { success: false, errors };
+  }
+
+  const data: CreateReminderEndpointInput = {
+    adapterKey: body.adapterKey as CreateReminderEndpointInput["adapterKey"],
+    label: sanitize((body.label as string).trim()),
+    target: (body.target as string).trim(),
+  };
+
+  if (body.metadata !== undefined) {
+    data.metadata = body.metadata as Record<string, unknown>;
+  }
+  if (body.enabled !== undefined) data.enabled = body.enabled as 0 | 1;
+
+  return { success: true, data };
+}
+
+export function validateUpdateReminderEndpoint(
+  body: unknown,
+): ValidationResult<UpdateReminderEndpointInput> {
+  if (!isRecord(body)) {
+    return {
+      success: false,
+      errors: [{ field: "body", message: "Request body must be an object" }],
+    };
+  }
+
+  const errors: ValidationError[] = [];
+
+  if (
+    body.label !== undefined &&
+    (typeof body.label !== "string" || sanitize(body.label).trim().length === 0)
+  ) {
+    errors.push({
+      field: "label",
+      message: "label must be a non-empty string",
+    });
+  }
+
+  if (
+    body.target !== undefined &&
+    (typeof body.target !== "string" || body.target.trim().length === 0)
+  ) {
+    errors.push({
+      field: "target",
+      message: "target must be a non-empty string",
+    });
+  }
+
+  if (
+    body.metadata !== undefined &&
+    body.metadata !== null &&
+    !isRecord(body.metadata)
+  ) {
+    errors.push({
+      field: "metadata",
+      message: "metadata must be an object or null",
+    });
+  }
+
+  if (body.enabled !== undefined && !isValidFlag(body.enabled)) {
+    errors.push({
+      field: "enabled",
+      message: "enabled must be 0 or 1",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { success: false, errors };
+  }
+
+  const data: UpdateReminderEndpointInput = {};
+
+  if (body.label !== undefined) {
+    data.label = sanitize((body.label as string).trim());
+  }
+  if (body.target !== undefined) {
+    data.target = (body.target as string).trim();
+  }
+  if (body.metadata !== undefined) {
+    data.metadata = body.metadata as Record<string, unknown> | null;
+  }
+  if (body.enabled !== undefined) {
+    data.enabled = body.enabled as 0 | 1;
+  }
+
+  return { success: true, data };
+}
+
+export function validateCreateTaskReminder(
+  body: unknown,
+): ValidationResult<Omit<CreateTaskReminderInput, "taskId">> {
+  if (!isRecord(body)) {
+    return {
+      success: false,
+      errors: [{ field: "body", message: "Request body must be an object" }],
+    };
+  }
+
+  const errors: ValidationError[] = [];
+
+  if (
+    typeof body.endpointId !== "number" ||
+    !Number.isInteger(body.endpointId) ||
+    body.endpointId <= 0
+  ) {
+    errors.push({
+      field: "endpointId",
+      message: "endpointId is required and must be a positive integer",
+    });
+  }
+
+  if (typeof body.anchor !== "string" || !isReminderAnchor(body.anchor)) {
+    errors.push({
+      field: "anchor",
+      message: "anchor must be one of: due, start",
+    });
+  }
+
+  if (
+    typeof body.offsetMinutes !== "number" ||
+    !Number.isInteger(body.offsetMinutes)
+  ) {
+    errors.push({
+      field: "offsetMinutes",
+      message: "offsetMinutes is required and must be an integer",
+    });
+  }
+
+  if (
+    body.allDayLocalTime !== undefined &&
+    body.allDayLocalTime !== null &&
+    (typeof body.allDayLocalTime !== "string" ||
+      !isValidAllDayLocalTime(body.allDayLocalTime))
+  ) {
+    errors.push({
+      field: "allDayLocalTime",
+      message: "allDayLocalTime must be in HH:MM format",
+    });
+  }
+
+  if (body.enabled !== undefined && !isValidFlag(body.enabled)) {
+    errors.push({
+      field: "enabled",
+      message: "enabled must be 0 or 1",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { success: false, errors };
+  }
+
+  const data: Omit<CreateTaskReminderInput, "taskId"> = {
+    endpointId: body.endpointId as number,
+    anchor: body.anchor as Omit<CreateTaskReminderInput, "taskId">["anchor"],
+    offsetMinutes: body.offsetMinutes as number,
+  };
+
+  if (body.allDayLocalTime !== undefined) {
+    data.allDayLocalTime = body.allDayLocalTime as string | null;
+  }
+  if (body.enabled !== undefined) {
+    data.enabled = body.enabled as 0 | 1;
+  }
+
+  return { success: true, data };
+}
+
+export function validateUpdateTaskReminder(
+  body: unknown,
+): ValidationResult<UpdateTaskReminderInput> {
+  if (!isRecord(body)) {
+    return {
+      success: false,
+      errors: [{ field: "body", message: "Request body must be an object" }],
+    };
+  }
+
+  const errors: ValidationError[] = [];
+
+  if (
+    body.endpointId !== undefined &&
+    (typeof body.endpointId !== "number" ||
+      !Number.isInteger(body.endpointId) ||
+      body.endpointId <= 0)
+  ) {
+    errors.push({
+      field: "endpointId",
+      message: "endpointId must be a positive integer",
+    });
+  }
+
+  if (
+    body.anchor !== undefined &&
+    (typeof body.anchor !== "string" || !isReminderAnchor(body.anchor))
+  ) {
+    errors.push({
+      field: "anchor",
+      message: "anchor must be one of: due, start",
+    });
+  }
+
+  if (
+    body.offsetMinutes !== undefined &&
+    (typeof body.offsetMinutes !== "number" ||
+      !Number.isInteger(body.offsetMinutes))
+  ) {
+    errors.push({
+      field: "offsetMinutes",
+      message: "offsetMinutes must be an integer",
+    });
+  }
+
+  if (
+    body.allDayLocalTime !== undefined &&
+    body.allDayLocalTime !== null &&
+    (typeof body.allDayLocalTime !== "string" ||
+      !isValidAllDayLocalTime(body.allDayLocalTime))
+  ) {
+    errors.push({
+      field: "allDayLocalTime",
+      message: "allDayLocalTime must be in HH:MM format or null",
+    });
+  }
+
+  if (body.enabled !== undefined && !isValidFlag(body.enabled)) {
+    errors.push({
+      field: "enabled",
+      message: "enabled must be 0 or 1",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { success: false, errors };
+  }
+
+  const data: UpdateTaskReminderInput = {};
+
+  if (body.endpointId !== undefined)
+    data.endpointId = body.endpointId as number;
+  if (body.anchor !== undefined) {
+    data.anchor = body.anchor as UpdateTaskReminderInput["anchor"];
+  }
+  if (body.offsetMinutes !== undefined) {
+    data.offsetMinutes = body.offsetMinutes as number;
+  }
+  if (body.allDayLocalTime !== undefined) {
+    data.allDayLocalTime = body.allDayLocalTime as string | null;
+  }
+  if (body.enabled !== undefined) data.enabled = body.enabled as 0 | 1;
+
+  return { success: true, data };
+}

--- a/tests/api/reminders.test.ts
+++ b/tests/api/reminders.test.ts
@@ -1,0 +1,500 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createReminderEndpoint,
+  getReminderEndpoint,
+} from "@/core/reminders/endpoints";
+import { listReminderAdapters } from "@/core/reminders/registry";
+import {
+  createTaskReminder,
+  getTaskReminder,
+  listTaskReminders,
+} from "@/core/reminders/rules";
+import { createTask } from "@/core/task";
+import type { Db } from "@/core/types";
+import { createTestDb, createTestUser } from "../helpers";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const mockState = vi.hoisted(() => ({
+  db: null as Db | null,
+  user: null as { id: number } | null,
+}));
+
+vi.mock("@/db", () => ({
+  get db() {
+    return mockState.db;
+  },
+}));
+
+vi.mock("@/lib/auth-middleware", () => ({
+  getAuthUserFromRequest: vi.fn(async () => mockState.user),
+  unauthorized: () =>
+    new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+import { GET as getReminderAdapters } from "@/app/api/reminders/adapters/route";
+import {
+  DELETE as deleteReminderEndpointById,
+  GET as getReminderEndpointById,
+  PATCH as patchReminderEndpointById,
+} from "@/app/api/reminders/endpoints/[id]/route";
+import {
+  POST as createReminderEndpointRoute,
+  GET as listReminderEndpointsRoute,
+} from "@/app/api/reminders/endpoints/route";
+import {
+  DELETE as deleteTaskReminderRoute,
+  PATCH as patchTaskReminderRoute,
+} from "@/app/api/tasks/[id]/reminders/[reminderId]/route";
+import {
+  POST as createTaskReminderRoute,
+  GET as listTaskRemindersRoute,
+} from "@/app/api/tasks/[id]/reminders/route";
+
+function buildRequest(
+  path: string,
+  init: {
+    method?: string;
+    body?: unknown;
+  } = {},
+): Request {
+  const headers = new Headers();
+  let body: string | undefined;
+
+  if (init.body !== undefined) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(init.body);
+  }
+
+  return new Request(`http://localhost${path}`, {
+    method: init.method ?? "GET",
+    headers,
+    body,
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+  mockState.db = createTestDb();
+  mockState.user = createTestUser(mockState.db);
+});
+
+describe("GET /api/reminders/adapters", () => {
+  it("returns unauthorized without an authenticated user", async () => {
+    mockState.user = null;
+
+    const response = await getReminderAdapters(
+      buildRequest("/api/reminders/adapters"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns reminder adapter manifests", async () => {
+    const response = await getReminderAdapters(
+      buildRequest("/api/reminders/adapters"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(listReminderAdapters());
+  });
+});
+
+describe("/api/reminders/endpoints", () => {
+  it("lists only the current user's reminder endpoints", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const otherUser = createTestUser(db);
+    const mine = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "My phone",
+      target: "+15125550101",
+    });
+
+    createReminderEndpoint(db, otherUser.id, {
+      adapterKey: "telegram.bot_api",
+      label: "Other bot",
+      target: "999",
+    });
+
+    const response = await listReminderEndpointsRoute(
+      buildRequest("/api/reminders/endpoints"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: mine.id,
+      adapterKey: "sms.twilio",
+      label: "My phone",
+      target: "+15125550101",
+    });
+  });
+
+  it("creates a reminder endpoint", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+
+    const response = await createReminderEndpointRoute(
+      buildRequest("/api/reminders/endpoints", {
+        method: "POST",
+        body: {
+          adapterKey: "slack.webhook",
+          label: "Work Slack",
+          target: "https://slack.test/hook",
+          metadata: { channel: "alerts" },
+          enabled: 0,
+        },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toMatchObject({
+      adapterKey: "slack.webhook",
+      label: "Work Slack",
+      target: "https://slack.test/hook",
+      metadata: { channel: "alerts" },
+      enabled: 0,
+    });
+    expect(getReminderEndpoint(db, userId, body.id)?.target).toBe(
+      "https://slack.test/hook",
+    );
+  });
+
+  it("rejects invalid endpoint payloads", async () => {
+    const response = await createReminderEndpointRoute(
+      buildRequest("/api/reminders/endpoints", {
+        method: "POST",
+        body: {
+          adapterKey: "email.smtp",
+          label: "",
+          target: "",
+        },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Validation failed");
+  });
+});
+
+describe("/api/reminders/endpoints/[id]", () => {
+  it("returns 404 for another user's endpoint", async () => {
+    const db = mockState.db as Db;
+    const otherUser = createTestUser(db);
+    const endpoint = createReminderEndpoint(db, otherUser.id, {
+      adapterKey: "sms.twilio",
+      label: "Other phone",
+      target: "+15125550102",
+    });
+
+    const response = await getReminderEndpointById(
+      buildRequest(`/api/reminders/endpoints/${endpoint.id}`),
+      { params: Promise.resolve({ id: String(endpoint.id) }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "Reminder endpoint not found",
+    });
+  });
+
+  it("updates an endpoint and can clear metadata", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "discord.webhook",
+      label: "Discord",
+      target: "https://discord.test/hook",
+      metadata: { guild: "one" },
+    });
+
+    const response = await patchReminderEndpointById(
+      buildRequest(`/api/reminders/endpoints/${endpoint.id}`, {
+        method: "PATCH",
+        body: {
+          label: "Discord alerts",
+          target: "https://discord.test/new-hook",
+          metadata: null,
+          enabled: 0,
+        },
+      }),
+      { params: Promise.resolve({ id: String(endpoint.id) }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      id: endpoint.id,
+      label: "Discord alerts",
+      target: "https://discord.test/new-hook",
+      metadata: null,
+      enabled: 0,
+    });
+    expect(getReminderEndpoint(db, userId, endpoint.id)?.target).toBe(
+      "https://discord.test/new-hook",
+    );
+  });
+
+  it("deletes an endpoint", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "Telegram",
+      target: "321",
+    });
+
+    const response = await deleteReminderEndpointById(
+      buildRequest(`/api/reminders/endpoints/${endpoint.id}`, {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id: String(endpoint.id) }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(getReminderEndpoint(db, userId, endpoint.id)).toBeNull();
+  });
+});
+
+describe("/api/tasks/[id]/reminders", () => {
+  it("lists reminders for a single owned task", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "Phone",
+      target: "+15125550103",
+    });
+    const task = createTask(db, userId, { description: "Task A" });
+    const otherTask = createTask(db, userId, { description: "Task B" });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -15,
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: otherTask.id,
+      endpointId: endpoint.id,
+      anchor: "start",
+      offsetMinutes: 0,
+    });
+
+    const response = await listTaskRemindersRoute(
+      buildRequest(`/api/tasks/${task.id}/reminders`),
+      { params: Promise.resolve({ id: String(task.id) }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: reminder.id,
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -15,
+    });
+  });
+
+  it("creates a reminder for an owned task and endpoint", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "signal.signal_cli",
+      label: "Signal",
+      target: "+15125550104",
+    });
+    const task = createTask(db, userId, { description: "Task with reminder" });
+
+    const response = await createTaskReminderRoute(
+      buildRequest(`/api/tasks/${task.id}/reminders`, {
+        method: "POST",
+        body: {
+          endpointId: endpoint.id,
+          anchor: "start",
+          offsetMinutes: 10,
+          allDayLocalTime: "08:30",
+          enabled: 0,
+        },
+      }),
+      { params: Promise.resolve({ id: String(task.id) }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toMatchObject({
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "start",
+      offsetMinutes: 10,
+      allDayLocalTime: "08:30",
+      enabled: 0,
+    });
+    expect(getTaskReminder(db, userId, body.id)?.endpointId).toBe(endpoint.id);
+  });
+
+  it("rejects creating a reminder with another user's endpoint", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const otherUser = createTestUser(db);
+    const endpoint = createReminderEndpoint(db, otherUser.id, {
+      adapterKey: "slack.webhook",
+      label: "Other webhook",
+      target: "https://slack.test/other",
+    });
+    const task = createTask(db, userId, { description: "Task" });
+
+    const response = await createTaskReminderRoute(
+      buildRequest(`/api/tasks/${task.id}/reminders`, {
+        method: "POST",
+        body: {
+          endpointId: endpoint.id,
+          anchor: "due",
+          offsetMinutes: -5,
+        },
+      }),
+      { params: Promise.resolve({ id: String(task.id) }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "Reminder endpoint not found",
+    });
+  });
+});
+
+describe("/api/tasks/[id]/reminders/[reminderId]", () => {
+  it("updates a task reminder scoped to its task", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpointA = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "Phone A",
+      target: "+15125550105",
+    });
+    const endpointB = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "Phone B",
+      target: "456",
+    });
+    const task = createTask(db, userId, { description: "Scoped task" });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpointA.id,
+      anchor: "due",
+      offsetMinutes: -20,
+    });
+
+    const response = await patchTaskReminderRoute(
+      buildRequest(`/api/tasks/${task.id}/reminders/${reminder.id}`, {
+        method: "PATCH",
+        body: {
+          endpointId: endpointB.id,
+          anchor: "start",
+          offsetMinutes: 15,
+          allDayLocalTime: null,
+          enabled: 0,
+        },
+      }),
+      {
+        params: Promise.resolve({
+          id: String(task.id),
+          reminderId: String(reminder.id),
+        }),
+      },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      id: reminder.id,
+      taskId: task.id,
+      endpointId: endpointB.id,
+      anchor: "start",
+      offsetMinutes: 15,
+      allDayLocalTime: null,
+      enabled: 0,
+    });
+  });
+
+  it("deletes a task reminder", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "discord.webhook",
+      label: "Discord",
+      target: "https://discord.test/delete",
+    });
+    const task = createTask(db, userId, {
+      description: "Delete reminder task",
+    });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -30,
+    });
+
+    const response = await deleteTaskReminderRoute(
+      buildRequest(`/api/tasks/${task.id}/reminders/${reminder.id}`, {
+        method: "DELETE",
+      }),
+      {
+        params: Promise.resolve({
+          id: String(task.id),
+          reminderId: String(reminder.id),
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(listTaskReminders(db, userId, task.id)).toHaveLength(0);
+  });
+
+  it("returns 404 when the reminder is not attached to the task path", async () => {
+    const db = mockState.db as Db;
+    const userId = mockState.user?.id as number;
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "Phone",
+      target: "+15125550106",
+    });
+    const taskA = createTask(db, userId, { description: "Task A" });
+    const taskB = createTask(db, userId, { description: "Task B" });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: taskA.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -5,
+    });
+
+    const response = await patchTaskReminderRoute(
+      buildRequest(`/api/tasks/${taskB.id}/reminders/${reminder.id}`, {
+        method: "PATCH",
+        body: { offsetMinutes: 0 },
+      }),
+      {
+        params: Promise.resolve({
+          id: String(taskB.id),
+          reminderId: String(reminder.id),
+        }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Task reminder not found" });
+  });
+});

--- a/tests/core/reminders/worker-scheduler.test.ts
+++ b/tests/core/reminders/worker-scheduler.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestDb } from "../../helpers";
+
+const cron = vi.hoisted(() => ({
+  firstJob: { stop: vi.fn() },
+  secondJob: { stop: vi.fn() },
+  schedule: vi.fn(),
+}));
+
+vi.mock("node-cron", () => ({
+  schedule: cron.schedule,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  cron.firstJob.stop.mockReset();
+  cron.secondJob.stop.mockReset();
+  cron.schedule.mockReset();
+  cron.schedule
+    .mockReturnValueOnce(cron.firstJob)
+    .mockReturnValueOnce(cron.secondJob);
+});
+
+describe("startReminderWorker", () => {
+  it("schedules a minute job and stops the previous worker before restarting", async () => {
+    const db = createTestDb();
+    const { startReminderWorker, stopReminderWorker } = await import(
+      "@/core/reminders/worker"
+    );
+
+    startReminderWorker(db);
+    expect(cron.schedule).toHaveBeenCalledWith(
+      "* * * * *",
+      expect.any(Function),
+    );
+
+    startReminderWorker(db);
+    expect(cron.firstJob.stop).toHaveBeenCalledOnce();
+
+    stopReminderWorker();
+    expect(cron.secondJob.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/core/reminders/worker.test.ts
+++ b/tests/core/reminders/worker.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  claimReminderDelivery,
+  enqueueReminderDelivery,
+  getReminderDelivery,
+  markReminderDeliveryFailed,
+} from "@/core/reminders/deliveries";
+import { createReminderEndpoint } from "@/core/reminders/endpoints";
+import { createTaskReminder } from "@/core/reminders/rules";
+import { runReminderWorker } from "@/core/reminders/worker";
+import { completeTask, createTask, deleteTask } from "@/core/task";
+import type { Db } from "@/core/types";
+import { createTestDb, createTestUser } from "../../helpers";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+let db: Db;
+let userId: number;
+
+beforeEach(() => {
+  vi.stubEnv("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+  db = createTestDb();
+  userId = createTestUser(db).id;
+});
+
+describe("runReminderWorker", () => {
+  it("enqueues due reminder deliveries", () => {
+    const task = createTask(db, userId, {
+      description: "Due soon",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "Phone",
+      target: "+15125550107",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    const result = runReminderWorker(db, {
+      nowIso: "2026-04-06T15:20:00.000Z",
+      userTimezoneResolver: () => "UTC",
+    });
+
+    expect(result.enqueued).toHaveLength(1);
+    expect(result.enqueued[0]).toMatchObject({
+      taskId: task.id,
+      endpointId: endpoint.id,
+      status: "pending",
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+  });
+
+  it("does not enqueue future reminder deliveries", () => {
+    const task = createTask(db, userId, {
+      description: "Not due yet",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "Telegram",
+      target: "777",
+    });
+
+    createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+
+    const result = runReminderWorker(db, {
+      nowIso: "2026-04-06T15:19:00.000Z",
+      userTimezoneResolver: () => "UTC",
+    });
+
+    expect(result.enqueued).toHaveLength(0);
+  });
+});
+
+describe("task lifecycle reminder suppression", () => {
+  it("suppresses pending deliveries when a task is completed", () => {
+    const task = createTask(db, userId, {
+      description: "Complete me",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "sms.twilio",
+      label: "Phone",
+      target: "+15125550108",
+    });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: endpoint.adapterKey,
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    completeTask(db, userId, task.id);
+
+    expect(getReminderDelivery(db, delivery.id)?.status).toBe("suppressed");
+  });
+
+  it("suppresses failed deliveries when a task is cancelled", () => {
+    const task = createTask(db, userId, {
+      description: "Cancel me",
+      due: "2026-04-06T15:30:00.000Z",
+    });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "discord.webhook",
+      label: "Discord",
+      target: "https://discord.test/worker",
+    });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -10,
+    });
+    const delivery = enqueueReminderDelivery(db, {
+      userId,
+      taskId: task.id,
+      taskReminderId: reminder.id,
+      endpointId: endpoint.id,
+      adapterKey: endpoint.adapterKey,
+      scheduledFor: "2026-04-06T15:20:00.000Z",
+    });
+
+    claimReminderDelivery(db, delivery.id, "2026-04-06T15:20:00.000Z");
+    markReminderDeliveryFailed(db, delivery.id, "temporary outage");
+
+    deleteTask(db, task.id);
+
+    expect(getReminderDelivery(db, delivery.id)?.status).toBe("suppressed");
+  });
+});


### PR DESCRIPTION
## Summary
- add authenticated reminder API routes for adapter manifests, reusable reminder endpoints, and task-scoped reminder rules
- add reminder-specific request validation so adapter keys, anchors, flags, offsets, and local-time fields are checked at the API boundary
- add a dedicated minute-tick reminder worker that materializes due reminder deliveries and suppresses pending or failed deliveries when tasks are completed or cancelled

#### Test plan
- [x] `scripts/ci.sh`