### PR TITLE
feat(reminders): add quick-view reminder editor

### DIFF
--- a/src/components/task-panel-reminders.tsx
+++ b/src/components/task-panel-reminders.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
+import type { ReminderAnchor } from "@/core/reminders/types";
+import {
+  buildReminderOffsetMinutes,
+  formatTaskPanelReminderSummary,
+  getReminderOffsetDirection,
+  getReminderOffsetMagnitude,
+  type ReminderOffsetDirection,
+  type TaskPanelReminderDraft,
+} from "@/lib/task-panel-reminders";
+
+interface TaskPanelRemindersProps {
+  allDay: boolean;
+  endpoints: ReminderEndpointRecord[];
+  reminders: TaskPanelReminderDraft[];
+  loading: boolean;
+  error: string | null;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  onAddReminder: () => void;
+  onChangeReminder: (
+    clientId: string,
+    patch: Partial<Omit<TaskPanelReminderDraft, "clientId">>,
+  ) => void;
+  onRemoveReminder: (clientId: string) => void;
+}
+
+export function TaskPanelReminders({
+  allDay,
+  endpoints,
+  reminders,
+  loading,
+  error,
+  expanded,
+  onExpandedChange,
+  onAddReminder,
+  onChangeReminder,
+  onRemoveReminder,
+}: TaskPanelRemindersProps) {
+  const endpointMap = useMemo(
+    () => new Map(endpoints.map((endpoint) => [endpoint.id, endpoint])),
+    [endpoints],
+  );
+
+  const toggleLabel = expanded ? "done" : reminders.length > 0 ? "edit" : "add";
+
+  return (
+    <div className="px-4 py-3 border-b border-border/40">
+      <div className="grid grid-cols-[4rem_1fr] gap-x-3 gap-y-2 items-start">
+        <span className="text-xs text-muted-foreground/60">reminders</span>
+        <div className="space-y-2 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-wrap gap-1 min-w-0">
+              {loading ? (
+                <span className="text-xs text-muted-foreground">
+                  loading...
+                </span>
+              ) : reminders.length === 0 ? (
+                <span className="text-xs text-muted-foreground">none</span>
+              ) : (
+                reminders.map((reminder) => (
+                  <Badge
+                    key={reminder.clientId}
+                    variant={reminder.enabled === 1 ? "outline" : "ghost"}
+                    className="max-w-full"
+                  >
+                    <span className="truncate">
+                      {formatTaskPanelReminderSummary(reminder, endpointMap, {
+                        allDay,
+                      })}
+                      {reminder.enabled === 0 ? " · off" : ""}
+                    </span>
+                  </Badge>
+                ))
+              )}
+            </div>
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              onClick={() => onExpandedChange(!expanded)}
+            >
+              {toggleLabel}
+            </Button>
+          </div>
+
+          {expanded && (
+            <div className="space-y-3">
+              {error && <div className="text-xs text-destructive">{error}</div>}
+
+              {!loading && endpoints.length === 0 ? (
+                <div className="text-xs text-muted-foreground">
+                  no reminder endpoints configured yet
+                </div>
+              ) : (
+                <>
+                  {reminders.map((reminder, index) => (
+                    <ReminderEditorRow
+                      key={reminder.clientId}
+                      allDay={allDay}
+                      endpoints={endpoints}
+                      reminder={reminder}
+                      index={index}
+                      onChangeReminder={onChangeReminder}
+                      onRemoveReminder={onRemoveReminder}
+                    />
+                  ))}
+
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={onAddReminder}
+                    disabled={loading || endpoints.length === 0}
+                  >
+                    add reminder
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReminderEditorRow({
+  allDay,
+  endpoints,
+  reminder,
+  index,
+  onChangeReminder,
+  onRemoveReminder,
+}: {
+  allDay: boolean;
+  endpoints: ReminderEndpointRecord[];
+  reminder: TaskPanelReminderDraft;
+  index: number;
+  onChangeReminder: (
+    clientId: string,
+    patch: Partial<Omit<TaskPanelReminderDraft, "clientId">>,
+  ) => void;
+  onRemoveReminder: (clientId: string) => void;
+}) {
+  const direction = getReminderOffsetDirection(reminder.offsetMinutes);
+  const magnitude = getReminderOffsetMagnitude(reminder.offsetMinutes);
+
+  return (
+    <div className="border border-border/60 px-2 py-2 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] text-muted-foreground/60">
+          reminder {index + 1}
+        </span>
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          onClick={() => onRemoveReminder(reminder.clientId)}
+        >
+          remove
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <div className="space-y-1">
+          <span className="text-[11px] text-muted-foreground/60">endpoint</span>
+          <Select
+            value={
+              reminder.endpointId !== null ? String(reminder.endpointId) : ""
+            }
+            onValueChange={(value) => {
+              if (!value) return;
+              onChangeReminder(reminder.clientId, {
+                endpointId: Number(value),
+              });
+            }}
+          >
+            <SelectTrigger size="sm" className="h-7 text-xs w-full">
+              <SelectValue placeholder="select endpoint" />
+            </SelectTrigger>
+            <SelectContent alignItemWithTrigger={false}>
+              {endpoints.map((endpoint) => (
+                <SelectItem key={endpoint.id} value={String(endpoint.id)}>
+                  {endpoint.enabled === 1
+                    ? endpoint.label
+                    : `${endpoint.label} (off)`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <span className="text-[11px] text-muted-foreground/60">timing</span>
+          <div className="flex flex-wrap items-center gap-2">
+            <AnchorSelect
+              value={reminder.anchor}
+              onValueChange={(value) =>
+                onChangeReminder(reminder.clientId, { anchor: value })
+              }
+            />
+            <DirectionSelect
+              value={direction}
+              onValueChange={(value) =>
+                onChangeReminder(reminder.clientId, {
+                  offsetMinutes: buildReminderOffsetMinutes(value, magnitude),
+                })
+              }
+            />
+            <Input
+              type="number"
+              min="0"
+              step="1"
+              value={String(magnitude)}
+              disabled={direction === "at"}
+              onChange={(e) =>
+                onChangeReminder(reminder.clientId, {
+                  offsetMinutes: buildReminderOffsetMinutes(
+                    direction,
+                    Number(e.target.value),
+                  ),
+                })
+              }
+              className="h-7 text-xs w-20"
+            />
+            <span className="text-xs text-muted-foreground/60">min</span>
+          </div>
+        </div>
+
+        {allDay && (
+          <div className="space-y-1">
+            <span className="text-[11px] text-muted-foreground/60">
+              local time
+            </span>
+            <Input
+              type="time"
+              value={reminder.allDayLocalTime ?? ""}
+              onChange={(e) =>
+                onChangeReminder(reminder.clientId, {
+                  allDayLocalTime: e.target.value || null,
+                })
+              }
+              className="h-7 text-xs w-28"
+            />
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Checkbox
+            checked={reminder.enabled === 1}
+            onCheckedChange={(checked) =>
+              onChangeReminder(reminder.clientId, {
+                enabled: checked ? 1 : 0,
+              })
+            }
+          />
+          <span>enabled</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AnchorSelect({
+  value,
+  onValueChange,
+}: {
+  value: ReminderAnchor;
+  onValueChange: (value: ReminderAnchor) => void;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(next) => {
+        if (!next) return;
+        onValueChange(next as ReminderAnchor);
+      }}
+    >
+      <SelectTrigger size="sm" className="h-7 text-xs w-24">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent alignItemWithTrigger={false}>
+        <SelectItem value="due">due</SelectItem>
+        <SelectItem value="start">start</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+function DirectionSelect({
+  value,
+  onValueChange,
+}: {
+  value: ReminderOffsetDirection;
+  onValueChange: (value: ReminderOffsetDirection) => void;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(next) => {
+        if (!next) return;
+        onValueChange(next as ReminderOffsetDirection);
+      }}
+    >
+      <SelectTrigger size="sm" className="h-7 text-xs w-24">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent alignItemWithTrigger={false}>
+        <SelectItem value="before">before</SelectItem>
+        <SelectItem value="after">after</SelectItem>
+        <SelectItem value="at">at</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/task-panel.tsx
+++ b/src/components/task-panel.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/app/actions/tasks";
 import { RecurrenceStrategyDialog } from "@/components/recurrence-strategy-dialog";
 import { ResizeHandle } from "@/components/resize-handle";
+import { TaskPanelReminders } from "@/components/task-panel-reminders";
 import { TiptapEditor } from "@/components/tiptap-editor";
 import { Input } from "@/components/ui/input";
 import {
@@ -23,12 +24,20 @@ import { useNavigation } from "@/contexts/navigation";
 import { useStatusBar } from "@/contexts/status-bar";
 import { useTaskPanel } from "@/contexts/task-panel";
 import { rruleToText } from "@/core/recurrence";
+import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
+import type { TaskReminder } from "@/core/reminders/types";
 import type { Task, TaskStatus } from "@/core/types";
 import { TASK_STATUSES } from "@/core/types";
 import { useLocationSearch } from "@/hooks/use-location-search";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useRecurrenceDelete } from "@/hooks/use-recurrence-delete";
 import { formatTime } from "@/lib/calendar-utils";
+import {
+  createTaskPanelReminderDraft,
+  type TaskPanelReminderDraft,
+  taskPanelRemindersEqual,
+  taskReminderToDraft,
+} from "@/lib/task-panel-reminders";
 import { detectMeetingPlatform } from "@/lib/utils";
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
@@ -38,6 +47,35 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
   blocked: "Blocked",
   cancelled: "Cancelled",
 };
+
+interface ApiErrorResponse {
+  error?: string;
+}
+
+async function fetchJson<T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(input, init);
+  const body = (await response.json().catch(() => null)) as
+    | ApiErrorResponse
+    | T
+    | null;
+
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body ? body.error : null;
+    throw new Error(typeof message === "string" ? message : "Request failed");
+  }
+
+  return body as T;
+}
+
+function cloneReminderDrafts(
+  drafts: TaskPanelReminderDraft[],
+): TaskPanelReminderDraft[] {
+  return drafts.map((draft) => ({ ...draft }));
+}
 
 export function TaskPanel({ tasks }: { tasks: Task[] }) {
   const panel = useTaskPanel();
@@ -61,6 +99,10 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
   );
   const taskRef = useRef(task);
   taskRef.current = task;
+  const activeTaskIdRef = useRef<number | null>(taskId);
+  activeTaskIdRef.current = taskId;
+  const panelOpenRef = useRef(isOpen);
+  panelOpenRef.current = isOpen;
 
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState("");
@@ -81,6 +123,20 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
   const pendingYRef = useRef(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const prevTaskIdRef = useRef<number | null>(null);
+  const reminderClientIdRef = useRef(0);
+  const reminderDraftsRef = useRef<TaskPanelReminderDraft[]>([]);
+  const initialReminderDraftsRef = useRef<TaskPanelReminderDraft[]>([]);
+  const remindersReadyRef = useRef(false);
+
+  const [reminderEndpoints, setReminderEndpoints] = useState<
+    ReminderEndpointRecord[]
+  >([]);
+  const [reminderDrafts, setReminderDrafts] = useState<
+    TaskPanelReminderDraft[]
+  >([]);
+  const [remindersExpanded, setRemindersExpanded] = useState(false);
+  const [remindersLoading, setRemindersLoading] = useState(false);
+  const [reminderError, setReminderError] = useState<string | null>(null);
 
   const formDataRef = useRef({
     description: "",
@@ -108,6 +164,229 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
     notes: notesRef.current,
   };
 
+  reminderDraftsRef.current = reminderDrafts;
+
+  const isAllDayTask =
+    mode === "edit" ? task?.allDay === 1 : preFill?.allDay === 1;
+  const defaultReminderAnchor =
+    !due &&
+    (mode === "edit" ? !!task?.startAt : !!preFill?.startAt) &&
+    !(mode === "edit" ? !!task?.due : !!preFill?.due)
+      ? "start"
+      : "due";
+
+  const createReminderClientId = useCallback(() => {
+    reminderClientIdRef.current += 1;
+    return `reminder-${reminderClientIdRef.current}`;
+  }, []);
+
+  const resetReminderState = useCallback(() => {
+    setReminderEndpoints([]);
+    setReminderDrafts([]);
+    setRemindersExpanded(false);
+    setRemindersLoading(false);
+    setReminderError(null);
+    initialReminderDraftsRef.current = [];
+    remindersReadyRef.current = false;
+  }, []);
+
+  const loadReminderState = useCallback(
+    async (panelMode: "edit" | "create", currentTaskId: number | null) => {
+      const endpoints = await fetchJson<ReminderEndpointRecord[]>(
+        "/api/reminders/endpoints",
+      );
+      const reminders =
+        panelMode === "edit" && currentTaskId
+          ? await fetchJson<TaskReminder[]>(
+              `/api/tasks/${currentTaskId}/reminders`,
+            )
+          : [];
+      const drafts = reminders.map((reminder) =>
+        taskReminderToDraft(reminder, createReminderClientId()),
+      );
+
+      return { endpoints, drafts };
+    },
+    [createReminderClientId],
+  );
+
+  const buildReminderPayload = useCallback(
+    (reminder: TaskPanelReminderDraft) => {
+      if (reminder.endpointId === null) {
+        throw new Error("Reminder endpoint is required");
+      }
+
+      return {
+        endpointId: reminder.endpointId,
+        anchor: reminder.anchor,
+        offsetMinutes: reminder.offsetMinutes,
+        allDayLocalTime: reminder.allDayLocalTime,
+        enabled: reminder.enabled,
+      };
+    },
+    [],
+  );
+
+  const saveTaskReminders = useCallback(
+    async (
+      currentTaskId: number,
+      input?: {
+        initial: TaskPanelReminderDraft[];
+        current: TaskPanelReminderDraft[];
+        applyState?: boolean;
+      },
+    ) => {
+      if (!remindersReadyRef.current && !input) return true;
+
+      const initial = input?.initial ?? initialReminderDraftsRef.current;
+      const current = input?.current ?? reminderDraftsRef.current;
+      const initialById = new Map(
+        initial
+          .filter((reminder) => reminder.id !== null)
+          .map((reminder) => [reminder.id as number, reminder]),
+      );
+      const currentIds = new Set(
+        current
+          .filter((reminder) => reminder.id !== null)
+          .map((reminder) => reminder.id as number),
+      );
+      const deletedIds = initial
+        .filter(
+          (reminder) => reminder.id !== null && !currentIds.has(reminder.id),
+        )
+        .map((reminder) => reminder.id as number);
+      const created = current.filter((reminder) => reminder.id === null);
+      const updated = current.filter((reminder) => {
+        if (reminder.id === null) return false;
+        const existing = initialById.get(reminder.id);
+        return existing ? !taskPanelRemindersEqual(existing, reminder) : false;
+      });
+
+      if (
+        deletedIds.length === 0 &&
+        created.length === 0 &&
+        updated.length === 0
+      ) {
+        return true;
+      }
+
+      for (const id of deletedIds) {
+        await fetchJson<{ ok: boolean }>(
+          `/api/tasks/${currentTaskId}/reminders/${id}`,
+          {
+            method: "DELETE",
+          },
+        );
+      }
+
+      const createdByClientId = new Map<string, TaskReminder>();
+      for (const reminder of created) {
+        const saved = await fetchJson<TaskReminder>(
+          `/api/tasks/${currentTaskId}/reminders`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(buildReminderPayload(reminder)),
+          },
+        );
+        createdByClientId.set(reminder.clientId, saved);
+      }
+
+      const updatedById = new Map<number, TaskReminder>();
+      for (const reminder of updated) {
+        const saved = await fetchJson<TaskReminder>(
+          `/api/tasks/${currentTaskId}/reminders/${reminder.id}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(buildReminderPayload(reminder)),
+          },
+        );
+        updatedById.set(reminder.id as number, saved);
+      }
+
+      const nextDrafts = current
+        .filter(
+          (reminder) =>
+            reminder.id === null || !deletedIds.includes(reminder.id),
+        )
+        .map((reminder) => {
+          const createdReminder = createdByClientId.get(reminder.clientId);
+          if (createdReminder) {
+            return taskReminderToDraft(createdReminder, reminder.clientId);
+          }
+
+          if (reminder.id !== null && updatedById.has(reminder.id as number)) {
+            return taskReminderToDraft(
+              updatedById.get(reminder.id as number) as TaskReminder,
+              reminder.clientId,
+            );
+          }
+
+          return reminder;
+        });
+
+      if (
+        input?.applyState !== false &&
+        panelOpenRef.current &&
+        activeTaskIdRef.current === currentTaskId
+      ) {
+        initialReminderDraftsRef.current = nextDrafts;
+        reminderDraftsRef.current = nextDrafts;
+        setReminderDrafts(nextDrafts);
+      }
+
+      return true;
+    },
+    [buildReminderPayload],
+  );
+
+  const updateReminderDraft = useCallback(
+    (
+      clientId: string,
+      patch: Partial<Omit<TaskPanelReminderDraft, "clientId">>,
+    ) => {
+      setReminderDrafts((prev) =>
+        prev.map((reminder) =>
+          reminder.clientId === clientId ? { ...reminder, ...patch } : reminder,
+        ),
+      );
+    },
+    [],
+  );
+
+  const removeReminderDraft = useCallback((clientId: string) => {
+    setReminderDrafts((prev) =>
+      prev.filter((reminder) => reminder.clientId !== clientId),
+    );
+  }, []);
+
+  const addReminderDraft = useCallback(() => {
+    if (reminderEndpoints.length === 0) {
+      setRemindersExpanded(true);
+      return;
+    }
+
+    const endpoint =
+      reminderEndpoints.find((candidate) => candidate.enabled === 1) ??
+      reminderEndpoints[0];
+
+    setReminderDrafts((prev) => [
+      ...prev,
+      createTaskPanelReminderDraft(createReminderClientId(), {
+        endpointId: endpoint?.id ?? null,
+        anchor: defaultReminderAnchor,
+        allDay: isAllDayTask,
+      }),
+    ]);
+    setRemindersExpanded(true);
+  }, [
+    createReminderClientId,
+    defaultReminderAnchor,
+    isAllDayTask,
+    reminderEndpoints,
+  ]);
+
   useEffect(() => {
     if (mode === "edit" && taskId) {
       setPendingEdit(taskId, {
@@ -132,6 +411,45 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
       if (taskId) clearPendingEdit(taskId);
     };
   }, [taskId, clearPendingEdit]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetReminderState();
+      return;
+    }
+
+    let active = true;
+    setRemindersLoading(true);
+    setReminderError(null);
+    setRemindersExpanded(false);
+    remindersReadyRef.current = false;
+
+    void loadReminderState(mode, taskId)
+      .then(({ endpoints, drafts }) => {
+        if (!active) return;
+        setReminderEndpoints(endpoints);
+        setReminderDrafts(drafts);
+        initialReminderDraftsRef.current = drafts;
+        remindersReadyRef.current = true;
+      })
+      .catch((error) => {
+        if (!active) return;
+        setReminderEndpoints([]);
+        setReminderDrafts([]);
+        initialReminderDraftsRef.current = [];
+        setReminderError(
+          error instanceof Error ? error.message : "Failed to load reminders",
+        );
+      })
+      .finally(() => {
+        if (!active) return;
+        setRemindersLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [isOpen, loadReminderState, mode, resetReminderState, taskId]);
 
   const allCategories = useMemo(() => {
     const cats = new Set<string>();
@@ -205,26 +523,55 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
 
   const { results: locationResults } = useLocationSearch(location);
 
-  const saveTask = useCallback(async (id: number) => {
-    const f = formDataRef.current;
-    await updateTaskAction(id, {
-      description: f.description,
-      category: f.category || null,
-      due: f.due ? new Date(f.due).toISOString() : null,
-      notes: f.notes || null,
-      location: f.location || null,
-      locationLat: f.location ? f.locationLat : null,
-      locationLon: f.location ? f.locationLon : null,
-      meetingUrl: f.meetingUrl || null,
-      recurrence: f.recurrence || null,
-      recurMode: f.recurrence ? f.recurMode : null,
-    });
-  }, []);
+  const saveTask = useCallback(
+    async (id: number, options?: { applyReminderState?: boolean }) => {
+      const f = formDataRef.current;
+      const initialReminderDrafts = cloneReminderDrafts(
+        initialReminderDraftsRef.current,
+      );
+      const currentReminderDrafts = cloneReminderDrafts(
+        reminderDraftsRef.current,
+      );
+      const result = await updateTaskAction(id, {
+        description: f.description,
+        category: f.category || null,
+        due: f.due ? new Date(f.due).toISOString() : null,
+        notes: f.notes || null,
+        location: f.location || null,
+        locationLat: f.location ? f.locationLat : null,
+        locationLon: f.location ? f.locationLon : null,
+        meetingUrl: f.meetingUrl || null,
+        recurrence: f.recurrence || null,
+        recurMode: f.recurrence ? f.recurMode : null,
+      });
+
+      if ("error" in result) {
+        statusBar.error(result.error);
+        return false;
+      }
+
+      try {
+        await saveTaskReminders(id, {
+          initial: initialReminderDrafts,
+          current: currentReminderDrafts,
+          applyState: options?.applyReminderState,
+        });
+      } catch (error) {
+        statusBar.error(
+          error instanceof Error ? error.message : "Failed to save reminders",
+        );
+        return false;
+      }
+
+      return true;
+    },
+    [saveTaskReminders, statusBar],
+  );
 
   useEffect(() => {
     const prevId = prevTaskIdRef.current;
     if (prevId && prevId !== taskId) {
-      saveTask(prevId);
+      void saveTask(prevId, { applyReminderState: false });
     }
     prevTaskIdRef.current = taskId;
 
@@ -277,7 +624,7 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
     if (!isOpen) return;
     return () => {
       const id = prevTaskIdRef.current;
-      if (id) saveTask(id);
+      if (id) void saveTask(id, { applyReminderState: false });
       prevTaskIdRef.current = null;
     };
   }, [isOpen, saveTask]);
@@ -285,6 +632,12 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
   const handleCreate = useCallback(async () => {
     const trimmed = description.trim();
     if (!trimmed) return;
+    const initialReminderDrafts = cloneReminderDrafts(
+      initialReminderDraftsRef.current,
+    );
+    const currentReminderDrafts = cloneReminderDrafts(
+      reminderDraftsRef.current,
+    );
 
     const result = await createTaskAction({
       description: trimmed,
@@ -304,7 +657,25 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
     });
 
     if ("data" in result && result.data) {
+      try {
+        await saveTaskReminders(result.data.id, {
+          initial: initialReminderDrafts,
+          current: currentReminderDrafts,
+          applyState: false,
+        });
+      } catch (error) {
+        statusBar.error(
+          error instanceof Error
+            ? `task created, but ${error.message.toLowerCase()}`
+            : "task created, but reminders failed to save",
+        );
+      }
       panel.close();
+      return;
+    }
+
+    if ("error" in result) {
+      statusBar.error(result.error);
     }
   }, [
     description,
@@ -318,6 +689,8 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
     recurMode,
     preFill,
     panel,
+    saveTaskReminders,
+    statusBar,
   ]);
 
   async function handleStatusChange(status: string) {
@@ -351,8 +724,8 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
     (e: React.KeyboardEvent) => {
       if (keymaps.resolvedMatchesEvent("task_detail.save", e.nativeEvent)) {
         e.preventDefault();
-        if (mode === "edit" && task) saveTask(task.id);
-        else if (mode === "create") handleCreate();
+        if (mode === "edit" && task) void saveTask(task.id);
+        else if (mode === "create") void handleCreate();
         return;
       }
 
@@ -361,9 +734,16 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
       if (e.key === closeKey) {
         e.preventDefault();
         e.stopPropagation();
-        if (mode === "edit" && task) saveTask(task.id);
-        if (mode === "create" && description.trim()) handleCreate();
-        panel.close();
+        if (mode === "edit" && task) {
+          void saveTask(task.id, { applyReminderState: false });
+          panel.close();
+        } else if (mode === "create") {
+          if (description.trim()) {
+            void handleCreate();
+          } else {
+            panel.close();
+          }
+        }
         return;
       }
 
@@ -418,12 +798,13 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
   }, [isOpen, mode, task, panel]);
 
   useEffect(() => {
-    function onSave() {
+    async function onSave() {
       if (mode === "edit" && task) {
-        saveTask(task.id);
-        statusBar.message("saved");
+        if (await saveTask(task.id)) {
+          statusBar.message("saved");
+        }
       } else if (mode === "create") {
-        handleCreate();
+        await handleCreate();
       }
     }
     function onDiscard() {
@@ -458,7 +839,9 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
               type="button"
               className="text-xs text-muted-foreground hover:text-foreground mb-2 min-h-[44px] flex items-center"
               onClick={() => {
-                if (mode === "edit" && task) saveTask(task.id);
+                if (mode === "edit" && task) {
+                  void saveTask(task.id, { applyReminderState: false });
+                }
                 panel.close();
               }}
             >
@@ -697,6 +1080,19 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
               )}
           </div>
         </div>
+
+        <TaskPanelReminders
+          allDay={isAllDayTask}
+          endpoints={reminderEndpoints}
+          reminders={reminderDrafts}
+          loading={remindersLoading}
+          error={reminderError}
+          expanded={remindersExpanded}
+          onExpandedChange={setRemindersExpanded}
+          onAddReminder={addReminderDraft}
+          onChangeReminder={updateReminderDraft}
+          onRemoveReminder={removeReminderDraft}
+        />
 
         <div className="flex-1 min-h-0 overflow-auto px-4 pt-3 pb-4">
           <TiptapEditor

--- a/src/lib/task-panel-reminders.ts
+++ b/src/lib/task-panel-reminders.ts
@@ -1,0 +1,145 @@
+import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
+import type { ReminderAnchor, TaskReminder } from "@/core/reminders/types";
+
+export interface TaskPanelReminderDraft {
+  clientId: string;
+  id: number | null;
+  endpointId: number | null;
+  anchor: ReminderAnchor;
+  offsetMinutes: number;
+  allDayLocalTime: string | null;
+  enabled: 0 | 1;
+}
+
+export type ReminderOffsetDirection = "before" | "after" | "at";
+
+type TaskPanelReminderFields = Omit<TaskPanelReminderDraft, "clientId">;
+
+export function createTaskPanelReminderDraft(
+  clientId: string,
+  input: {
+    endpointId: number | null;
+    anchor: ReminderAnchor;
+    allDay: boolean;
+  },
+): TaskPanelReminderDraft {
+  return {
+    clientId,
+    id: null,
+    endpointId: input.endpointId,
+    anchor: input.anchor,
+    offsetMinutes: input.allDay ? 0 : -15,
+    allDayLocalTime: input.allDay ? "09:00" : null,
+    enabled: 1,
+  };
+}
+
+export function taskReminderToDraft(
+  reminder: Pick<
+    TaskReminder,
+    | "id"
+    | "endpointId"
+    | "anchor"
+    | "offsetMinutes"
+    | "allDayLocalTime"
+    | "enabled"
+  >,
+  clientId: string,
+): TaskPanelReminderDraft {
+  return {
+    clientId,
+    id: reminder.id,
+    endpointId: reminder.endpointId,
+    anchor: reminder.anchor,
+    offsetMinutes: reminder.offsetMinutes,
+    allDayLocalTime: reminder.allDayLocalTime,
+    enabled: reminder.enabled === 1 ? 1 : 0,
+  };
+}
+
+export function getReminderOffsetDirection(
+  offsetMinutes: number,
+): ReminderOffsetDirection {
+  if (offsetMinutes < 0) return "before";
+  if (offsetMinutes > 0) return "after";
+  return "at";
+}
+
+export function getReminderOffsetMagnitude(offsetMinutes: number): number {
+  return Math.abs(offsetMinutes);
+}
+
+export function buildReminderOffsetMinutes(
+  direction: ReminderOffsetDirection,
+  magnitude: number,
+): number {
+  const normalized = Math.max(
+    0,
+    Math.floor(Number.isFinite(magnitude) ? magnitude : 0),
+  );
+  if (direction === "before") return normalized * -1;
+  if (direction === "after") return normalized;
+  return 0;
+}
+
+export function taskPanelRemindersEqual(
+  a: TaskPanelReminderFields,
+  b: TaskPanelReminderFields,
+): boolean {
+  return (
+    a.id === b.id &&
+    a.endpointId === b.endpointId &&
+    a.anchor === b.anchor &&
+    a.offsetMinutes === b.offsetMinutes &&
+    a.allDayLocalTime === b.allDayLocalTime &&
+    a.enabled === b.enabled
+  );
+}
+
+function formatReminderDuration(totalMinutes: number): string {
+  const minutes = Math.max(0, Math.floor(totalMinutes));
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  const mins = minutes % 60;
+  const parts: string[] = [];
+
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (mins > 0 || parts.length === 0) parts.push(`${mins}m`);
+
+  return parts.join(" ");
+}
+
+export function formatTaskPanelReminderSummary(
+  reminder: Pick<
+    TaskPanelReminderDraft,
+    "endpointId" | "anchor" | "offsetMinutes" | "allDayLocalTime"
+  >,
+  endpoints: Map<number, Pick<ReminderEndpointRecord, "id" | "label">>,
+  options: { allDay: boolean },
+): string {
+  const endpointLabel =
+    (reminder.endpointId !== null
+      ? endpoints.get(reminder.endpointId)?.label
+      : null) ?? "unknown endpoint";
+
+  if (options.allDay && reminder.allDayLocalTime) {
+    if (reminder.offsetMinutes === 0) {
+      return `${reminder.allDayLocalTime} on ${reminder.anchor} day → ${endpointLabel}`;
+    }
+
+    return `${reminder.allDayLocalTime}, ${formatReminderDuration(
+      Math.abs(reminder.offsetMinutes),
+    )} ${reminder.offsetMinutes < 0 ? "before" : "after"} ${
+      reminder.anchor
+    } → ${endpointLabel}`;
+  }
+
+  if (reminder.offsetMinutes === 0) {
+    return `at ${reminder.anchor} → ${endpointLabel}`;
+  }
+
+  return `${formatReminderDuration(Math.abs(reminder.offsetMinutes))} ${
+    reminder.offsetMinutes < 0 ? "before" : "after"
+  } ${reminder.anchor} → ${endpointLabel}`;
+}

--- a/tests/lib/task-panel-reminders.test.ts
+++ b/tests/lib/task-panel-reminders.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReminderOffsetMinutes,
+  createTaskPanelReminderDraft,
+  formatTaskPanelReminderSummary,
+  getReminderOffsetDirection,
+  getReminderOffsetMagnitude,
+  taskPanelRemindersEqual,
+  taskReminderToDraft,
+} from "@/lib/task-panel-reminders";
+
+const endpoints = new Map([
+  [1, { id: 1, label: "personal sms" }],
+  [2, { id: 2, label: "telegram" }],
+]);
+
+describe("task panel reminder helpers", () => {
+  it("creates timed reminder drafts with a default pre-send offset", () => {
+    expect(
+      createTaskPanelReminderDraft("draft-1", {
+        endpointId: 1,
+        anchor: "due",
+        allDay: false,
+      }),
+    ).toEqual({
+      clientId: "draft-1",
+      id: null,
+      endpointId: 1,
+      anchor: "due",
+      offsetMinutes: -15,
+      allDayLocalTime: null,
+      enabled: 1,
+    });
+  });
+
+  it("creates all-day reminder drafts with a local reminder time", () => {
+    expect(
+      createTaskPanelReminderDraft("draft-2", {
+        endpointId: 2,
+        anchor: "start",
+        allDay: true,
+      }),
+    ).toEqual({
+      clientId: "draft-2",
+      id: null,
+      endpointId: 2,
+      anchor: "start",
+      offsetMinutes: 0,
+      allDayLocalTime: "09:00",
+      enabled: 1,
+    });
+  });
+
+  it("round-trips reminder offset direction and magnitude", () => {
+    expect(getReminderOffsetDirection(-90)).toBe("before");
+    expect(getReminderOffsetMagnitude(-90)).toBe(90);
+    expect(buildReminderOffsetMinutes("before", 90)).toBe(-90);
+    expect(buildReminderOffsetMinutes("after", 120)).toBe(120);
+    expect(buildReminderOffsetMinutes("at", 45)).toBe(0);
+  });
+
+  it("formats timed reminder summaries", () => {
+    expect(
+      formatTaskPanelReminderSummary(
+        {
+          endpointId: 1,
+          anchor: "due",
+          offsetMinutes: -90,
+          allDayLocalTime: null,
+        },
+        endpoints,
+        { allDay: false },
+      ),
+    ).toBe("1h 30m before due → personal sms");
+  });
+
+  it("formats all-day reminder summaries with a local time", () => {
+    expect(
+      formatTaskPanelReminderSummary(
+        {
+          endpointId: 2,
+          anchor: "due",
+          offsetMinutes: 0,
+          allDayLocalTime: "09:00",
+        },
+        endpoints,
+        { allDay: true },
+      ),
+    ).toBe("09:00 on due day → telegram");
+  });
+
+  it("compares reminder drafts by persisted fields", () => {
+    const draft = taskReminderToDraft(
+      {
+        id: 3,
+        endpointId: 1,
+        anchor: "due",
+        offsetMinutes: -15,
+        allDayLocalTime: null,
+        enabled: 1,
+      },
+      "draft-3",
+    );
+
+    expect(
+      taskPanelRemindersEqual(
+        {
+          id: draft.id,
+          endpointId: draft.endpointId,
+          anchor: draft.anchor,
+          offsetMinutes: draft.offsetMinutes,
+          allDayLocalTime: draft.allDayLocalTime,
+          enabled: draft.enabled,
+        },
+        {
+          id: 3,
+          endpointId: 1,
+          anchor: "due",
+          offsetMinutes: -15,
+          allDayLocalTime: null,
+          enabled: 1,
+        },
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated reminders section to the task panel between task metadata and notes
- support inline reminder editing for existing tasks plus staged reminder creation for new tasks
- add helper coverage for reminder draft formatting and offset behavior

Closes #203.

#### Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/lib/task-panel-reminders.test.ts tests/api/reminders.test.ts`
- [x] `nix develop /home/barrett/dev/delta -c biome check /home/barrett/dev/delta/src/components/task-panel.tsx /home/barrett/dev/delta/src/components/task-panel-reminders.tsx /home/barrett/dev/delta/src/lib/task-panel-reminders.ts /home/barrett/dev/delta/tests/lib/task-panel-reminders.test.ts`
- [x] `/home/barrett/dev/delta/scripts/ci.sh`