### PR TITLE
feat(reminders): add endpoint settings UI

### DIFF
--- a/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/src/app/(dashboard)/settings/integrations/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 import { IntegrationsSection } from "@/components/settings/integrations-section";
 import { validateSession } from "@/core/auth";
 import { getIntegrationConfig } from "@/core/integration-config";
+import { listReminderEndpoints } from "@/core/reminders/endpoints";
+import { listReminderAdapters } from "@/core/reminders/registry";
 import { db } from "@/db";
 
 export default async function SettingsIntegrationsPage() {
@@ -35,6 +37,8 @@ export default async function SettingsIntegrationsPage() {
   const conflictResolution =
     (gcal?.metadata?.conflictResolution as string) ?? "google_wins";
   const syncInterval = (gcal?.metadata?.syncInterval as number) ?? 5;
+  const reminderEndpoints = listReminderEndpoints(db, user.id);
+  const reminderAdapters = listReminderAdapters();
 
   return (
     <IntegrationsSection
@@ -45,6 +49,8 @@ export default async function SettingsIntegrationsPage() {
       }
       initialSyncInterval={syncInterval as 5 | 15 | 30}
       initialNlpProvider={nlpProvider}
+      initialReminderEndpoints={reminderEndpoints}
+      reminderAdapters={reminderAdapters}
     />
   );
 }

--- a/src/components/settings/integrations-section.tsx
+++ b/src/components/settings/integrations-section.tsx
@@ -2,9 +2,12 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { ReminderEndpointsSection } from "@/components/settings/reminder-endpoints-section";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useStatusBar } from "@/contexts/status-bar";
+import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
+import type { ReminderAdapterManifest } from "@/core/reminders/types";
 import type { NlpProvider } from "@/lib/nlp-models";
 import {
   SettingsPage,
@@ -46,12 +49,16 @@ export function IntegrationsSection({
   initialConflictResolution = "google_wins",
   initialSyncInterval = 5,
   initialNlpProvider = null,
+  initialReminderEndpoints = [],
+  reminderAdapters = [],
 }: {
   gcalConnected: boolean;
   initialGeoProvider?: GeoProvider;
   initialConflictResolution?: ConflictResolution;
   initialSyncInterval?: SyncInterval;
   initialNlpProvider?: NlpProvider | null;
+  initialReminderEndpoints?: ReminderEndpointRecord[];
+  reminderAdapters?: ReminderAdapterManifest[];
 }) {
   const router = useRouter();
   const statusBar = useStatusBar();
@@ -383,6 +390,11 @@ export function IntegrationsSection({
           </div>
         ))}
       </SettingsSection>
+
+      <ReminderEndpointsSection
+        initialEndpoints={initialReminderEndpoints}
+        adapters={reminderAdapters}
+      />
     </SettingsPage>
   );
 }

--- a/src/components/settings/reminder-endpoints-section.tsx
+++ b/src/components/settings/reminder-endpoints-section.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useStatusBar } from "@/contexts/status-bar";
+import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
+import type { ReminderAdapterManifest } from "@/core/reminders/types";
+import {
+  getReminderEndpointAdapterHint,
+  getReminderEndpointTargetLabel,
+  getReminderEndpointTargetPlaceholder,
+} from "@/lib/reminder-endpoint-form";
+import { SettingsSection } from "./settings-primitives";
+
+interface ApiErrorResponse {
+  error?: string;
+}
+
+interface ReminderEndpointTestResponse {
+  ok: true;
+  providerMessageId: string | null;
+}
+
+async function parseApiError(response: Response): Promise<string> {
+  const body = (await response
+    .json()
+    .catch(() => null)) as ApiErrorResponse | null;
+  return typeof body?.error === "string" ? body.error : "request failed";
+}
+
+export function ReminderEndpointsSection({
+  initialEndpoints,
+  adapters,
+}: {
+  initialEndpoints: ReminderEndpointRecord[];
+  adapters: ReminderAdapterManifest[];
+}) {
+  const statusBar = useStatusBar();
+  const adapterByKey = useMemo(
+    () => new Map(adapters.map((adapter) => [adapter.key, adapter])),
+    [adapters],
+  );
+  const [endpoints, setEndpoints] = useState(initialEndpoints);
+  const [creating, setCreating] = useState(false);
+  const [createAdapterKey, setCreateAdapterKey] =
+    useState<ReminderAdapterManifest["key"]>("slack.webhook");
+  const [createLabel, setCreateLabel] = useState("");
+  const [createTarget, setCreateTarget] = useState("");
+  const [testingIds, setTestingIds] = useState<number[]>([]);
+  const [deletingIds, setDeletingIds] = useState<number[]>([]);
+
+  const selectedAdapter =
+    adapters.find((adapter) => adapter.key === createAdapterKey) ?? adapters[0];
+  const targetLabel = getReminderEndpointTargetLabel(createAdapterKey);
+  const targetPlaceholder =
+    getReminderEndpointTargetPlaceholder(createAdapterKey);
+  const adapterHint = selectedAdapter
+    ? getReminderEndpointAdapterHint(selectedAdapter)
+    : null;
+
+  function resetCreateForm() {
+    setCreateAdapterKey("slack.webhook");
+    setCreateLabel("");
+    setCreateTarget("");
+    setCreating(false);
+  }
+
+  async function handleCreateEndpoint() {
+    if (!createLabel.trim() || !createTarget.trim()) {
+      statusBar.error("label and target are required");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      const response = await fetch("/api/reminders/endpoints", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          adapterKey: createAdapterKey,
+          label: createLabel.trim(),
+          target: createTarget.trim(),
+        }),
+      });
+      if (!response.ok) {
+        statusBar.error(await parseApiError(response));
+        return;
+      }
+
+      const endpoint = (await response.json()) as ReminderEndpointRecord;
+      setEndpoints((prev) => [...prev, endpoint]);
+      resetCreateForm();
+      statusBar.message("reminder endpoint added");
+    } catch {
+      statusBar.error("failed to create reminder endpoint");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleTestEndpoint(id: number) {
+    setTestingIds((prev) => [...prev, id]);
+    try {
+      const response = await fetch(`/api/reminders/endpoints/${id}/test`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!response.ok) {
+        const error = await parseApiError(response);
+        setEndpoints((prev) =>
+          prev.map((endpoint) =>
+            endpoint.id === id
+              ? {
+                  ...endpoint,
+                  lastTestAt: new Date().toISOString(),
+                  lastTestStatus: "failed",
+                  lastTestError: error,
+                }
+              : endpoint,
+          ),
+        );
+        statusBar.error(error);
+        return;
+      }
+
+      const body = (await response.json()) as ReminderEndpointTestResponse;
+      setEndpoints((prev) =>
+        prev.map((endpoint) =>
+          endpoint.id === id
+            ? {
+                ...endpoint,
+                lastTestAt: new Date().toISOString(),
+                lastTestStatus: "ok",
+                lastTestError: null,
+              }
+            : endpoint,
+        ),
+      );
+      statusBar.message(
+        body.providerMessageId ? "test sent" : "test sent without provider id",
+      );
+    } catch {
+      statusBar.error("failed to test reminder endpoint");
+    } finally {
+      setTestingIds((prev) => prev.filter((candidate) => candidate !== id));
+    }
+  }
+
+  async function handleDeleteEndpoint(id: number) {
+    setDeletingIds((prev) => [...prev, id]);
+    try {
+      const response = await fetch(`/api/reminders/endpoints/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        statusBar.error(await parseApiError(response));
+        return;
+      }
+
+      setEndpoints((prev) => prev.filter((endpoint) => endpoint.id !== id));
+      statusBar.message("reminder endpoint deleted");
+    } catch {
+      statusBar.error("failed to delete reminder endpoint");
+    } finally {
+      setDeletingIds((prev) => prev.filter((candidate) => candidate !== id));
+    }
+  }
+
+  return (
+    <SettingsSection title="reminders">
+      <div className="space-y-2">
+        {endpoints.length === 0 ? (
+          <div className="px-2 py-2 text-sm text-muted-foreground">
+            no reminder endpoints yet
+          </div>
+        ) : (
+          endpoints.map((endpoint) => {
+            const adapter = adapterByKey.get(endpoint.adapterKey);
+            const hint = adapter
+              ? getReminderEndpointAdapterHint(adapter)
+              : null;
+            const testing = testingIds.includes(endpoint.id);
+            const deleting = deletingIds.includes(endpoint.id);
+
+            return (
+              <div
+                key={endpoint.id}
+                className="border border-border/60 px-2 py-2 space-y-2"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-sm truncate">{endpoint.label}</span>
+                      {adapter?.capabilities.beta && (
+                        <Badge variant="outline">beta</Badge>
+                      )}
+                      {endpoint.enabled === 0 && (
+                        <Badge variant="ghost">off</Badge>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      {adapter?.displayName ?? endpoint.adapterKey} ·{" "}
+                      {endpoint.target}
+                    </div>
+                    {hint && (
+                      <div className="text-xs text-muted-foreground truncate">
+                        {hint}
+                      </div>
+                    )}
+                    {endpoint.lastTestStatus && (
+                      <div
+                        className={`text-xs ${
+                          endpoint.lastTestStatus === "ok"
+                            ? "text-muted-foreground"
+                            : "text-destructive"
+                        }`}
+                      >
+                        last test {endpoint.lastTestStatus}
+                        {endpoint.lastTestError
+                          ? ` · ${endpoint.lastTestError}`
+                          : ""}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="outline"
+                      disabled={testing || deleting}
+                      onClick={() => handleTestEndpoint(endpoint.id)}
+                    >
+                      {testing ? "..." : "test"}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="ghost"
+                      disabled={testing || deleting}
+                      onClick={() => handleDeleteEndpoint(endpoint.id)}
+                    >
+                      {deleting ? "..." : "delete"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+
+        <div className="border border-border/60 px-2 py-2 space-y-2">
+          <div className="text-xs text-muted-foreground/60 uppercase tracking-wider">
+            add endpoint
+          </div>
+          <div className="space-y-2">
+            <Select
+              value={createAdapterKey}
+              onValueChange={(value) => {
+                if (!value) return;
+                setCreateAdapterKey(value as ReminderAdapterManifest["key"]);
+              }}
+            >
+              <SelectTrigger size="sm" className="h-8 text-sm w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent alignItemWithTrigger={false}>
+                {adapters.map((adapter) => (
+                  <SelectItem key={adapter.key} value={adapter.key}>
+                    {adapter.displayName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Input
+              value={createLabel}
+              onChange={(e) => setCreateLabel(e.target.value)}
+              placeholder="label"
+              className="h-8 text-sm"
+            />
+            <Input
+              value={createTarget}
+              onChange={(e) => setCreateTarget(e.target.value)}
+              placeholder={`${targetLabel}: ${targetPlaceholder}`}
+              className="h-8 text-sm"
+            />
+            {adapterHint && (
+              <div className="text-xs text-muted-foreground">{adapterHint}</div>
+            )}
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={creating}
+                onClick={handleCreateEndpoint}
+                className="h-7 text-xs"
+              >
+                {creating ? "..." : "save endpoint"}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={creating}
+                onClick={resetCreateForm}
+                className="h-7 text-xs"
+              >
+                clear
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/lib/reminder-endpoint-form.ts
+++ b/src/lib/reminder-endpoint-form.ts
@@ -1,0 +1,50 @@
+import type { ReminderAdapterManifest } from "@/core/reminders/types";
+
+export function getReminderEndpointTargetLabel(
+  adapterKey: ReminderAdapterManifest["key"],
+): string {
+  switch (adapterKey) {
+    case "sms.twilio":
+      return "phone number";
+    case "telegram.bot_api":
+      return "chat id";
+    case "slack.webhook":
+    case "discord.webhook":
+      return "webhook URL";
+    case "signal.signal_cli":
+      return "recipient";
+  }
+}
+
+export function getReminderEndpointTargetPlaceholder(
+  adapterKey: ReminderAdapterManifest["key"],
+): string {
+  switch (adapterKey) {
+    case "sms.twilio":
+      return "+15125550123";
+    case "telegram.bot_api":
+      return "123456789";
+    case "slack.webhook":
+    case "discord.webhook":
+      return "https://";
+    case "signal.signal_cli":
+      return "recipient";
+  }
+}
+
+export function getReminderEndpointAdapterHint(
+  adapter: Pick<
+    ReminderAdapterManifest,
+    "key" | "configScope" | "capabilities"
+  >,
+): string | null {
+  if (adapter.key === "signal.signal_cli") {
+    return "beta · signal-cli is not available yet";
+  }
+
+  if (adapter.configScope === "system") {
+    return "requires transport config";
+  }
+
+  return null;
+}

--- a/tests/lib/reminder-endpoint-form.test.ts
+++ b/tests/lib/reminder-endpoint-form.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  getReminderEndpointAdapterHint,
+  getReminderEndpointTargetLabel,
+  getReminderEndpointTargetPlaceholder,
+} from "@/lib/reminder-endpoint-form";
+
+describe("reminder endpoint form helpers", () => {
+  it("returns adapter-specific target labels", () => {
+    expect(getReminderEndpointTargetLabel("sms.twilio")).toBe("phone number");
+    expect(getReminderEndpointTargetLabel("telegram.bot_api")).toBe("chat id");
+    expect(getReminderEndpointTargetLabel("slack.webhook")).toBe("webhook URL");
+    expect(getReminderEndpointTargetLabel("signal.signal_cli")).toBe(
+      "recipient",
+    );
+  });
+
+  it("returns adapter-specific target placeholders", () => {
+    expect(getReminderEndpointTargetPlaceholder("sms.twilio")).toBe(
+      "+15125550123",
+    );
+    expect(getReminderEndpointTargetPlaceholder("telegram.bot_api")).toBe(
+      "123456789",
+    );
+    expect(getReminderEndpointTargetPlaceholder("discord.webhook")).toBe(
+      "https://",
+    );
+  });
+
+  it("returns system-config hints and Signal beta messaging", () => {
+    expect(
+      getReminderEndpointAdapterHint({
+        key: "sms.twilio",
+        configScope: "system",
+        capabilities: {
+          supportsDeliveryStatus: true,
+          supportsRichText: false,
+          supportsTestSend: true,
+          beta: false,
+        },
+      }),
+    ).toBe("requires transport config");
+
+    expect(
+      getReminderEndpointAdapterHint({
+        key: "signal.signal_cli",
+        configScope: "system",
+        capabilities: {
+          supportsDeliveryStatus: false,
+          supportsRichText: false,
+          supportsTestSend: true,
+          beta: true,
+        },
+      }),
+    ).toBe("beta · signal-cli is not available yet");
+
+    expect(
+      getReminderEndpointAdapterHint({
+        key: "slack.webhook",
+        configScope: "none",
+        capabilities: {
+          supportsDeliveryStatus: false,
+          supportsRichText: false,
+          supportsTestSend: true,
+          beta: false,
+        },
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reminders section to settings/integrations that lists reusable reminder endpoints
- support creating, testing, and deleting reminder endpoints with adapter-aware labels and hints
- pass reminder endpoints and adapter manifests from the server-rendered settings page into the integrations UI

Part of #202.

#### Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/lib/reminder-endpoint-form.test.ts`
- [x] `nix develop /home/barrett/dev/delta -c biome check /home/barrett/dev/delta/src/app/'(dashboard)'/settings/integrations/page.tsx /home/barrett/dev/delta/src/components/settings/integrations-section.tsx /home/barrett/dev/delta/src/components/settings/reminder-endpoints-section.tsx /home/barrett/dev/delta/src/lib/reminder-endpoint-form.ts /home/barrett/dev/delta/tests/lib/reminder-endpoint-form.test.ts`
- [x] `/home/barrett/dev/delta/scripts/ci.sh`