### PR TITLE
fix(settings): make keymaps layout two columns

### DIFF
--- a/src/components/settings/keymaps-section.tsx
+++ b/src/components/settings/keymaps-section.tsx
@@ -71,7 +71,7 @@ export function KeymapsSection() {
   }, [keymaps, allConfigurableIds, statusBar]);
 
   return (
-    <SettingsPage>
+    <SettingsPage className="max-w-4xl">
       {hasOverrides && (
         <div className="flex justify-end mb-4">
           <button
@@ -88,7 +88,7 @@ export function KeymapsSection() {
           key={section.section}
           title={SECTION_LABELS[section.section]}
         >
-          <div className="flex flex-col gap-1">
+          <div className="grid grid-cols-1 gap-x-6 gap-y-1 md:grid-cols-2">
             {section.rows.map((entry) => {
               const isSingleConfigurable =
                 entry.ids.length === 1 &&

--- a/src/components/settings/settings-primitives.tsx
+++ b/src/components/settings/settings-primitives.tsx
@@ -65,6 +65,12 @@ export function SettingsRow({
   );
 }
 
-export function SettingsPage({ children }: { children: React.ReactNode }) {
-  return <div className="w-full max-w-md px-6 py-6">{children}</div>;
+export function SettingsPage({
+  children,
+  className = "max-w-md",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={`w-full px-6 py-6 ${className}`}>{children}</div>;
 }


### PR DESCRIPTION
## Summary
- widen the keymaps settings page so it can use more of the settings content area
- render each keymaps section in a two-column grid for easier scanning
- preserve the existing key capture and reset behavior

#### Test plan
- [x] `nix develop -c biome check src/components/settings/settings-primitives.tsx src/components/settings/keymaps-section.tsx`
- [x] `nix develop -c pnpm typecheck`
- [x] `nix develop -c pnpm build`