### PR TITLE
fix(settings): color only account action prefixes

### DIFF
--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -101,10 +101,11 @@ export function AccountSection({
         {connectedAccounts.map((account) => (
           <SettingsRow
             key={account.id}
-            label={`- ${account.provider}`}
+            label={account.provider}
             value={account.name ?? account.email ?? account.providerAccountId}
             action
-            destructive
+            muted
+            prefix={{ text: "-", className: "text-destructive" }}
             onClick={() => handleUnlinkProvider(account.provider)}
           />
         ))}


### PR DESCRIPTION
## Summary
- keep connected account rows visually muted while still highlighting the unlink marker
- switch the account settings rows to the same prefix-only styling pattern used elsewhere in settings

#### Test plan
- [x] `nix develop -c biome check src/components/settings/account-section.tsx src/components/settings/settings-primitives.tsx`
- [x] `nix develop -c pnpm typecheck`
- [x] `nix develop -c pnpm build`