### PR TITLE
feat(reminders): add Twilio WhatsApp transport

### DIFF
--- a/src/components/settings/reminder-delivery-log-section.tsx
+++ b/src/components/settings/reminder-delivery-log-section.tsx
@@ -26,6 +26,16 @@ const OPERATOR_PLAYBOOKS: Playbook[] = [
     ],
   },
   {
+    adapterKey: "whatsapp.twilio",
+    steps: [
+      "Save the account SID, auth token, from number, messaging service SID, and content SID in transport config.",
+      "Create an approved WhatsApp template that expects {{1}} for the task text and {{2}} for the schedule line.",
+      "Add an endpoint with the recipient phone number in E.164 format.",
+      "Use the endpoint test action, then confirm the approved WhatsApp template renders and delivers correctly.",
+    ],
+    note: "Business-initiated reminders use an approved WhatsApp template through Twilio content templates rather than a free-form body.",
+  },
+  {
     adapterKey: "telegram.bot_api",
     steps: [
       "Save the bot token in transport config.",

--- a/src/core/reminders/registry.ts
+++ b/src/core/reminders/registry.ts
@@ -14,6 +14,18 @@ const MANIFESTS = [
     },
   },
   {
+    key: "whatsapp.twilio",
+    channel: "whatsapp",
+    displayName: "Twilio WhatsApp",
+    configScope: "system",
+    capabilities: {
+      supportsDeliveryStatus: true,
+      supportsRichText: false,
+      supportsTestSend: true,
+      beta: false,
+    },
+  },
+  {
     key: "telegram.bot_api",
     channel: "telegram",
     displayName: "Telegram Bot API",

--- a/src/core/reminders/runtime.ts
+++ b/src/core/reminders/runtime.ts
@@ -59,6 +59,49 @@ function requireSystemConfig(db: Db, key: string, label: string): string {
   return value;
 }
 
+function getTwilioMessagesUrl(accountSid: string): string {
+  return `https://api.twilio.com/2010-04-01/Accounts/${encodeURIComponent(accountSid)}/Messages.json`;
+}
+
+function getTwilioAuthorizationHeader(
+  accountSid: string,
+  authToken: string,
+): string {
+  return `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`;
+}
+
+function formatTwilioWhatsappAddress(value: string): string {
+  return value.startsWith("whatsapp:") ? value : `whatsapp:${value}`;
+}
+
+function getReminderScheduleLine(
+  task: Pick<Task, "due" | "startAt">,
+): string | null {
+  if (task.due) {
+    return `Due: ${task.due}`;
+  }
+
+  if (task.startAt) {
+    return `Starts: ${task.startAt}`;
+  }
+
+  return null;
+}
+
+function buildTwilioWhatsappContentVariables(
+  input: ReminderAdapterSendInput,
+): string {
+  const primaryLine = input.task?.description ?? input.body;
+  const secondaryLine = input.task
+    ? getReminderScheduleLine(input.task)
+    : "Reminder endpoint test from delta";
+
+  return JSON.stringify({
+    "1": primaryLine,
+    "2": secondaryLine ?? "Reminder from delta",
+  });
+}
+
 async function sendSlackWebhook(
   input: ReminderAdapterSendInput,
 ): Promise<ReminderAdapterSendResult> {
@@ -160,21 +203,72 @@ async function sendTwilioSms(
     "Twilio from number",
   );
 
-  const response = await fetch(
-    `https://api.twilio.com/2010-04-01/Accounts/${encodeURIComponent(accountSid)}/Messages.json`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString("base64")}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        To: input.endpoint.target,
-        From: fromNumber,
-        Body: input.body,
-      }),
+  const response = await fetch(getTwilioMessagesUrl(accountSid), {
+    method: "POST",
+    headers: {
+      Authorization: getTwilioAuthorizationHeader(accountSid, authToken),
+      "Content-Type": "application/x-www-form-urlencoded",
     },
+    body: new URLSearchParams({
+      To: input.endpoint.target,
+      From: fromNumber,
+      Body: input.body,
+    }),
+  });
+
+  if (!response.ok) {
+    await throwForHttpFailure(response);
+  }
+
+  const body = (await response.json()) as { sid?: string };
+  return {
+    providerMessageId: body.sid ?? null,
+  };
+}
+
+async function sendTwilioWhatsapp(
+  input: ReminderAdapterSendInput,
+): Promise<ReminderAdapterSendResult> {
+  const accountSid = requireSystemConfig(
+    input.db,
+    "reminders.whatsapp.twilio.account_sid",
+    "Twilio account SID",
   );
+  const authToken = requireSystemConfig(
+    input.db,
+    "reminders.whatsapp.twilio.auth_token",
+    "Twilio auth token",
+  );
+  const fromNumber = requireSystemConfig(
+    input.db,
+    "reminders.whatsapp.twilio.from_number",
+    "Twilio WhatsApp from number",
+  );
+  const messagingServiceSid = requireSystemConfig(
+    input.db,
+    "reminders.whatsapp.twilio.messaging_service_sid",
+    "Twilio Messaging Service SID",
+  );
+  const contentSid = requireSystemConfig(
+    input.db,
+    "reminders.whatsapp.twilio.content_sid",
+    "Twilio content SID",
+  );
+
+  const response = await fetch(getTwilioMessagesUrl(accountSid), {
+    method: "POST",
+    headers: {
+      Authorization: getTwilioAuthorizationHeader(accountSid, authToken),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      To: formatTwilioWhatsappAddress(input.endpoint.target),
+      From: formatTwilioWhatsappAddress(fromNumber),
+      MessagingServiceSid: messagingServiceSid,
+      ContentSid: contentSid,
+      ContentVariables: buildTwilioWhatsappContentVariables(input),
+    }),
+  });
 
   if (!response.ok) {
     await throwForHttpFailure(response);
@@ -204,6 +298,10 @@ function registerBuiltinReminderAdapterRuntimes() {
   runtimes.set("sms.twilio", {
     key: "sms.twilio",
     send: sendTwilioSms,
+  });
+  runtimes.set("whatsapp.twilio", {
+    key: "whatsapp.twilio",
+    send: sendTwilioWhatsapp,
   });
 }
 

--- a/src/core/reminders/types.ts
+++ b/src/core/reminders/types.ts
@@ -6,6 +6,7 @@ import type {
 
 export const REMINDER_CHANNELS = [
   "sms",
+  "whatsapp",
   "telegram",
   "discord",
   "slack",
@@ -14,6 +15,7 @@ export type ReminderChannel = (typeof REMINDER_CHANNELS)[number];
 
 export const REMINDER_ADAPTER_KEYS = [
   "sms.twilio",
+  "whatsapp.twilio",
   "telegram.bot_api",
   "discord.webhook",
   "slack.webhook",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -130,6 +130,7 @@ export const reminderEndpoints = sqliteTable("reminder_endpoints", {
   adapterKey: text("adapter_key", {
     enum: [
       "sms.twilio",
+      "whatsapp.twilio",
       "telegram.bot_api",
       "discord.webhook",
       "slack.webhook",
@@ -184,6 +185,7 @@ export const reminderDeliveries = sqliteTable(
     adapterKey: text("adapter_key", {
       enum: [
         "sms.twilio",
+        "whatsapp.twilio",
         "telegram.bot_api",
         "discord.webhook",
         "slack.webhook",

--- a/src/lib/reminder-endpoint-form.ts
+++ b/src/lib/reminder-endpoint-form.ts
@@ -6,6 +6,8 @@ export function getReminderEndpointTargetLabel(
   switch (adapterKey) {
     case "sms.twilio":
       return "phone number";
+    case "whatsapp.twilio":
+      return "WhatsApp number";
     case "telegram.bot_api":
       return "chat id";
     case "slack.webhook":
@@ -19,6 +21,8 @@ export function getReminderEndpointTargetPlaceholder(
 ): string {
   switch (adapterKey) {
     case "sms.twilio":
+      return "+15125550123";
+    case "whatsapp.twilio":
       return "+15125550123";
     case "telegram.bot_api":
       return "123456789";
@@ -34,6 +38,10 @@ export function getReminderEndpointAdapterHint(
     "key" | "configScope" | "capabilities"
   >,
 ): string | null {
+  if (adapter.key === "whatsapp.twilio") {
+    return "requires transport config · uses approved Twilio content template";
+  }
+
   if (adapter.configScope === "system") {
     return "requires transport config";
   }

--- a/src/lib/reminder-transport-form.ts
+++ b/src/lib/reminder-transport-form.ts
@@ -2,6 +2,7 @@ import type { ReminderAdapterKey } from "@/core/reminders/types";
 
 export const REMINDER_TRANSPORT_CONFIGURABLE_ADAPTER_KEYS = [
   "sms.twilio",
+  "whatsapp.twilio",
   "telegram.bot_api",
 ] as const;
 
@@ -44,6 +45,43 @@ const REMINDER_TRANSPORT_FIELDS = {
       placeholder: "+15125550123",
       inputType: "tel",
       systemConfigKey: "reminders.sms.twilio.from_number",
+    },
+  ],
+  "whatsapp.twilio": [
+    {
+      name: "accountSid",
+      label: "account SID",
+      placeholder: "AC123456789",
+      inputType: "text",
+      systemConfigKey: "reminders.whatsapp.twilio.account_sid",
+    },
+    {
+      name: "authToken",
+      label: "auth token",
+      placeholder: "auth token",
+      inputType: "password",
+      systemConfigKey: "reminders.whatsapp.twilio.auth_token",
+    },
+    {
+      name: "fromNumber",
+      label: "from number",
+      placeholder: "+15125550123",
+      inputType: "tel",
+      systemConfigKey: "reminders.whatsapp.twilio.from_number",
+    },
+    {
+      name: "messagingServiceSid",
+      label: "messaging service SID",
+      placeholder: "MG123456789",
+      inputType: "text",
+      systemConfigKey: "reminders.whatsapp.twilio.messaging_service_sid",
+    },
+    {
+      name: "contentSid",
+      label: "content SID",
+      placeholder: "HX123456789",
+      inputType: "text",
+      systemConfigKey: "reminders.whatsapp.twilio.content_sid",
     },
   ],
   "telegram.bot_api": [

--- a/tests/api/reminders.test.ts
+++ b/tests/api/reminders.test.ts
@@ -90,11 +90,12 @@ function buildRequest(
 function buildReminderTarget(
   adapterKey:
     | "sms.twilio"
+    | "whatsapp.twilio"
     | "telegram.bot_api"
     | "slack.webhook"
     | "discord.webhook",
 ) {
-  if (adapterKey === "sms.twilio") {
+  if (adapterKey === "sms.twilio" || adapterKey === "whatsapp.twilio") {
     return "+15125550100";
   }
   if (adapterKey === "telegram.bot_api") return "123456";
@@ -106,6 +107,7 @@ function createReminderDeliveryFixture(
     userId?: number;
     adapterKey?:
       | "sms.twilio"
+      | "whatsapp.twilio"
       | "telegram.bot_api"
       | "slack.webhook"
       | "discord.webhook";

--- a/tests/api/settings-reminder-transports.test.ts
+++ b/tests/api/settings-reminder-transports.test.ts
@@ -87,6 +87,26 @@ describe("/api/settings/reminders/transports/[adapter]", () => {
     });
   });
 
+  it("returns WhatsApp config status with required template fields", async () => {
+    const response = await GET(
+      buildRequest("/api/settings/reminders/transports/whatsapp.twilio"),
+      { params: Promise.resolve({ adapter: "whatsapp.twilio" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      adapterKey: "whatsapp.twilio",
+      configured: false,
+      missingFields: [
+        "accountSid",
+        "authToken",
+        "fromNumber",
+        "messagingServiceSid",
+        "contentSid",
+      ],
+    });
+  });
+
   it("stores Twilio transport config without exposing secrets", async () => {
     const response = await PUT(
       buildRequest("/api/settings/reminders/transports/sms.twilio", {
@@ -117,6 +137,61 @@ describe("/api/settings/reminders/transports/[adapter]", () => {
     expect(
       getSystemConfig(mockState.db as Db, "reminders.sms.twilio.from_number"),
     ).toBe("+15125550123");
+  });
+
+  it("stores WhatsApp transport config", async () => {
+    const response = await PUT(
+      buildRequest("/api/settings/reminders/transports/whatsapp.twilio", {
+        method: "PUT",
+        body: {
+          values: {
+            accountSid: " ACWA123 ",
+            authToken: " wa-token-123 ",
+            fromNumber: " +15125550124 ",
+            messagingServiceSid: " MG123456789 ",
+            contentSid: " HX123456789 ",
+          },
+        },
+      }),
+      { params: Promise.resolve({ adapter: "whatsapp.twilio" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      adapterKey: "whatsapp.twilio",
+      configured: true,
+      missingFields: [],
+    });
+    expect(
+      getSystemConfig(
+        mockState.db as Db,
+        "reminders.whatsapp.twilio.account_sid",
+      ),
+    ).toBe("ACWA123");
+    expect(
+      getSystemConfig(
+        mockState.db as Db,
+        "reminders.whatsapp.twilio.auth_token",
+      ),
+    ).toBe("wa-token-123");
+    expect(
+      getSystemConfig(
+        mockState.db as Db,
+        "reminders.whatsapp.twilio.from_number",
+      ),
+    ).toBe("+15125550124");
+    expect(
+      getSystemConfig(
+        mockState.db as Db,
+        "reminders.whatsapp.twilio.messaging_service_sid",
+      ),
+    ).toBe("MG123456789");
+    expect(
+      getSystemConfig(
+        mockState.db as Db,
+        "reminders.whatsapp.twilio.content_sid",
+      ),
+    ).toBe("HX123456789");
   });
 
   it("rejects invalid reminder transport payloads", async () => {

--- a/tests/core/reminders/deliveries.test.ts
+++ b/tests/core/reminders/deliveries.test.ts
@@ -29,6 +29,7 @@ let userId: number;
 function createDeliveryFixture(
   adapterKey:
     | "sms.twilio"
+    | "whatsapp.twilio"
     | "telegram.bot_api"
     | "slack.webhook"
     | "discord.webhook" = "sms.twilio",
@@ -41,7 +42,7 @@ function createDeliveryFixture(
     adapterKey,
     label: adapterKey,
     target:
-      adapterKey === "sms.twilio"
+      adapterKey === "sms.twilio" || adapterKey === "whatsapp.twilio"
         ? "+15125501381"
         : adapterKey === "telegram.bot_api"
           ? "1234"

--- a/tests/core/reminders/dispatch.test.ts
+++ b/tests/core/reminders/dispatch.test.ts
@@ -23,6 +23,7 @@ let userId: number;
 function createDeliveryFixture(
   adapterKey:
     | "sms.twilio"
+    | "whatsapp.twilio"
     | "telegram.bot_api"
     | "slack.webhook"
     | "discord.webhook",
@@ -137,6 +138,67 @@ describe("dispatchReminderDelivery", () => {
     expect(request.body.get("Body")).toContain("Task for sms.twilio");
   });
 
+  it("dispatches Twilio WhatsApp deliveries with template config", async () => {
+    setSystemConfig(db, "reminders.whatsapp.twilio.account_sid", "ACWA123");
+    setSystemConfig(db, "reminders.whatsapp.twilio.auth_token", "wa-token-123");
+    setSystemConfig(
+      db,
+      "reminders.whatsapp.twilio.from_number",
+      "+15125558888",
+    );
+    setSystemConfig(
+      db,
+      "reminders.whatsapp.twilio.messaging_service_sid",
+      "MG123456789",
+    );
+    setSystemConfig(db, "reminders.whatsapp.twilio.content_sid", "HX123456789");
+
+    const { delivery } = createDeliveryFixture(
+      "whatsapp.twilio",
+      "+15125550119",
+    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ sid: "SMWA123" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sent = await dispatchReminderDelivery(db, delivery.id, {
+      nowIso: "2026-04-06T15:20:00.000Z",
+    });
+
+    expect(sent?.status).toBe("sent");
+    expect(sent?.providerMessageId).toBe("SMWA123");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.twilio.com/2010-04-01/Accounts/ACWA123/Messages.json",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: `Basic ${Buffer.from("ACWA123:wa-token-123").toString("base64")}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      }),
+    );
+    const request = (
+      fetchMock.mock.calls[0] as unknown as [string, { body: URLSearchParams }]
+    )[1] as {
+      body: URLSearchParams;
+    };
+    expect(request.body.get("To")).toBe("whatsapp:+15125550119");
+    expect(request.body.get("From")).toBe("whatsapp:+15125558888");
+    expect(request.body.get("MessagingServiceSid")).toBe("MG123456789");
+    expect(request.body.get("ContentSid")).toBe("HX123456789");
+    expect(request.body.get("Body")).toBeNull();
+    expect(JSON.parse(request.body.get("ContentVariables") ?? "")).toEqual({
+      "1": "Task for whatsapp.twilio",
+      "2": "Due: 2026-04-06T15:30:00.000Z",
+    });
+  });
+
   it("marks permanent adapter failures as dead", async () => {
     const { delivery } = createDeliveryFixture(
       "discord.webhook",
@@ -211,6 +273,55 @@ describe("sendReminderEndpointTest", () => {
     expect(getReminderEndpoint(db, userId, endpoint.id)?.lastTestStatus).toBe(
       "failed",
     );
+  });
+
+  it("sends a WhatsApp endpoint test through Twilio templates", async () => {
+    setSystemConfig(db, "reminders.whatsapp.twilio.account_sid", "ACWA123");
+    setSystemConfig(db, "reminders.whatsapp.twilio.auth_token", "wa-token-123");
+    setSystemConfig(
+      db,
+      "reminders.whatsapp.twilio.from_number",
+      "+15125558888",
+    );
+    setSystemConfig(
+      db,
+      "reminders.whatsapp.twilio.messaging_service_sid",
+      "MG123456789",
+    );
+    setSystemConfig(db, "reminders.whatsapp.twilio.content_sid", "HX123456789");
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "whatsapp.twilio",
+      label: "WhatsApp",
+      target: "+15125550111",
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ sid: "SMWA456" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendReminderEndpointTest(db, userId, endpoint.id, {
+      body: "WhatsApp reminder test",
+    });
+
+    expect(result.endpoint.lastTestStatus).toBe("ok");
+    expect(result.providerMessageId).toBe("SMWA456");
+    const request = (
+      fetchMock.mock.calls[0] as unknown as [string, { body: URLSearchParams }]
+    )[1] as {
+      body: URLSearchParams;
+    };
+    expect(request.body.get("To")).toBe("whatsapp:+15125550111");
+    expect(request.body.get("From")).toBe("whatsapp:+15125558888");
+    expect(request.body.get("MessagingServiceSid")).toBe("MG123456789");
+    expect(request.body.get("ContentSid")).toBe("HX123456789");
+    expect(JSON.parse(request.body.get("ContentVariables") ?? "")).toEqual({
+      "1": "WhatsApp reminder test",
+      "2": "Reminder endpoint test from delta",
+    });
   });
 
   it("throws for nonexistent endpoints", async () => {

--- a/tests/core/reminders/registry.test.ts
+++ b/tests/core/reminders/registry.test.ts
@@ -54,12 +54,13 @@ describe("reminder adapter registry", () => {
   });
 
   it("returns adapter metadata by key", () => {
-    const adapter = getReminderAdapter("telegram.bot_api");
+    const adapter = getReminderAdapter("whatsapp.twilio");
 
     expect(adapter).not.toBeNull();
-    expect(adapter?.channel).toBe("telegram");
+    expect(adapter?.channel).toBe("whatsapp");
     expect(adapter?.configScope).toBe("system");
     expect(adapter?.capabilities.beta).toBe(false);
+    expect(adapter?.capabilities.supportsDeliveryStatus).toBe(true);
   });
 
   it("returns null for unknown adapters", () => {

--- a/tests/core/reminders/transport-config.test.ts
+++ b/tests/core/reminders/transport-config.test.ts
@@ -28,6 +28,17 @@ describe("reminder transport config", () => {
         missingFields: ["accountSid", "authToken", "fromNumber"],
       },
       {
+        adapterKey: "whatsapp.twilio",
+        configured: false,
+        missingFields: [
+          "accountSid",
+          "authToken",
+          "fromNumber",
+          "messagingServiceSid",
+          "contentSid",
+        ],
+      },
+      {
         adapterKey: "telegram.bot_api",
         configured: false,
         missingFields: ["botToken"],
@@ -55,6 +66,37 @@ describe("reminder transport config", () => {
     );
     expect(getSystemConfig(db, "reminders.sms.twilio.from_number")).toBe(
       "+15125550123",
+    );
+  });
+
+  it("stores and reports WhatsApp transport config", () => {
+    const status = setReminderTransportConfig(db, "whatsapp.twilio", {
+      accountSid: "ACWA123",
+      authToken: "wa-token-123",
+      fromNumber: "+15125550124",
+      messagingServiceSid: "MG123456789",
+      contentSid: "HX123456789",
+    });
+
+    expect(status).toEqual({
+      adapterKey: "whatsapp.twilio",
+      configured: true,
+      missingFields: [],
+    });
+    expect(getSystemConfig(db, "reminders.whatsapp.twilio.account_sid")).toBe(
+      "ACWA123",
+    );
+    expect(getSystemConfig(db, "reminders.whatsapp.twilio.auth_token")).toBe(
+      "wa-token-123",
+    );
+    expect(getSystemConfig(db, "reminders.whatsapp.twilio.from_number")).toBe(
+      "+15125550124",
+    );
+    expect(
+      getSystemConfig(db, "reminders.whatsapp.twilio.messaging_service_sid"),
+    ).toBe("MG123456789");
+    expect(getSystemConfig(db, "reminders.whatsapp.twilio.content_sid")).toBe(
+      "HX123456789",
     );
   });
 

--- a/tests/lib/reminder-delivery-log-section.test.ts
+++ b/tests/lib/reminder-delivery-log-section.test.ts
@@ -9,6 +9,7 @@ function createDelivery(input: {
   id: number;
   adapterKey:
     | "sms.twilio"
+    | "whatsapp.twilio"
     | "telegram.bot_api"
     | "slack.webhook"
     | "discord.webhook";
@@ -118,9 +119,11 @@ describe("ReminderDeliveryLogSection", () => {
     expect(html).toContain("delivery history");
     expect(html).toContain("operator playbooks");
     expect(html).toContain("Twilio SMS");
+    expect(html).toContain("Twilio WhatsApp");
     expect(html).toContain("Telegram Bot API");
     expect(html).toContain("Slack Webhook");
     expect(html).toContain("Discord Webhook");
+    expect(html).toContain("approved WhatsApp template");
   });
 
   it("renders empty states when no deliveries exist yet", () => {

--- a/tests/lib/reminder-endpoint-form.test.ts
+++ b/tests/lib/reminder-endpoint-form.test.ts
@@ -8,12 +8,18 @@ import {
 describe("reminder endpoint form helpers", () => {
   it("returns adapter-specific target labels", () => {
     expect(getReminderEndpointTargetLabel("sms.twilio")).toBe("phone number");
+    expect(getReminderEndpointTargetLabel("whatsapp.twilio")).toBe(
+      "WhatsApp number",
+    );
     expect(getReminderEndpointTargetLabel("telegram.bot_api")).toBe("chat id");
     expect(getReminderEndpointTargetLabel("slack.webhook")).toBe("webhook URL");
   });
 
   it("returns adapter-specific target placeholders", () => {
     expect(getReminderEndpointTargetPlaceholder("sms.twilio")).toBe(
+      "+15125550123",
+    );
+    expect(getReminderEndpointTargetPlaceholder("whatsapp.twilio")).toBe(
       "+15125550123",
     );
     expect(getReminderEndpointTargetPlaceholder("telegram.bot_api")).toBe(
@@ -37,6 +43,19 @@ describe("reminder endpoint form helpers", () => {
         },
       }),
     ).toBe("requires transport config");
+
+    expect(
+      getReminderEndpointAdapterHint({
+        key: "whatsapp.twilio",
+        configScope: "system",
+        capabilities: {
+          supportsDeliveryStatus: true,
+          supportsRichText: false,
+          supportsTestSend: true,
+          beta: false,
+        },
+      }),
+    ).toBe("requires transport config · uses approved Twilio content template");
 
     expect(
       getReminderEndpointAdapterHint({

--- a/tests/lib/reminder-transport-form.test.ts
+++ b/tests/lib/reminder-transport-form.test.ts
@@ -32,6 +32,44 @@ describe("reminder transport form helpers", () => {
       },
     ]);
 
+    expect(getReminderTransportFields("whatsapp.twilio")).toEqual([
+      {
+        name: "accountSid",
+        label: "account SID",
+        placeholder: "AC123456789",
+        inputType: "text",
+        systemConfigKey: "reminders.whatsapp.twilio.account_sid",
+      },
+      {
+        name: "authToken",
+        label: "auth token",
+        placeholder: "auth token",
+        inputType: "password",
+        systemConfigKey: "reminders.whatsapp.twilio.auth_token",
+      },
+      {
+        name: "fromNumber",
+        label: "from number",
+        placeholder: "+15125550123",
+        inputType: "tel",
+        systemConfigKey: "reminders.whatsapp.twilio.from_number",
+      },
+      {
+        name: "messagingServiceSid",
+        label: "messaging service SID",
+        placeholder: "MG123456789",
+        inputType: "text",
+        systemConfigKey: "reminders.whatsapp.twilio.messaging_service_sid",
+      },
+      {
+        name: "contentSid",
+        label: "content SID",
+        placeholder: "HX123456789",
+        inputType: "text",
+        systemConfigKey: "reminders.whatsapp.twilio.content_sid",
+      },
+    ]);
+
     expect(getReminderTransportFields("telegram.bot_api")).toEqual([
       {
         name: "botToken",
@@ -56,6 +94,25 @@ describe("reminder transport form helpers", () => {
         accountSid: "AC123",
         authToken: "token-123",
         fromNumber: "+15125550123",
+      },
+    });
+
+    expect(
+      normalizeReminderTransportConfigValues("whatsapp.twilio", {
+        accountSid: " ACWA123 ",
+        authToken: " wa-token-123 ",
+        fromNumber: " +15125550124 ",
+        messagingServiceSid: " MG123456789 ",
+        contentSid: " HX123456789 ",
+      }),
+    ).toEqual({
+      ok: true,
+      values: {
+        accountSid: "ACWA123",
+        authToken: "wa-token-123",
+        fromNumber: "+15125550124",
+        messagingServiceSid: "MG123456789",
+        contentSid: "HX123456789",
       },
     });
 


### PR DESCRIPTION
## Summary
- add a `whatsapp.twilio` reminder adapter with Twilio runtime support built around `ContentSid` and `ContentVariables`
- expose WhatsApp transport config in settings, including the Twilio messaging service and approved content template identifiers
- update reminder UI copy and automated tests to reflect the WhatsApp transport contract and supported adapter set

#### Test plan
- [x] ./scripts/ci.sh