### PR TITLE
fix(calendar): align create preview with task duration

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -31,6 +31,7 @@ import {
   formatDateKey,
   formatMonthTitle,
   formatWeekRange,
+  getCreatePreview,
   getDatesBetween,
   getMinutesFromMidnight,
   getWeekStart,
@@ -382,24 +383,8 @@ export function CalendarView({
   }, [tasks, optimisticUpdates]);
 
   const createPreview = useMemo(() => {
-    if (
-      panel.mode !== "create" ||
-      !panel.preFill?.startAt ||
-      panel.preFill.allDay
-    )
-      return null;
-    const start = new Date(panel.preFill.startAt);
-    const dayOffset = Math.floor(
-      (start.getTime() - weekAnchor.getTime()) / (1000 * 60 * 60 * 24),
-    );
-    if (dayOffset < 0 || dayOffset > 6) return null;
-    const startMin = start.getHours() * 60 + start.getMinutes();
-    let endMin = startMin + 60;
-    if (panel.preFill.endAt) {
-      const end = new Date(panel.preFill.endAt);
-      endMin = end.getHours() * 60 + end.getMinutes();
-    }
-    return { dayIndex: dayOffset, startMin, endMin };
+    if (panel.mode !== "create") return null;
+    return getCreatePreview(panel.preFill, weekAnchor);
   }, [panel.mode, panel.preFill, weekAnchor]);
 
   function handleDayClick(date: Date, _anchorEl?: HTMLElement) {

--- a/src/components/task-panel.tsx
+++ b/src/components/task-panel.tsx
@@ -31,7 +31,6 @@ import { TASK_STATUSES } from "@/core/types";
 import { useLocationSearch } from "@/hooks/use-location-search";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useRecurrenceDelete } from "@/hooks/use-recurrence-delete";
-import { formatTime } from "@/lib/calendar-utils";
 import {
   createTaskPanelReminderDraft,
   type TaskPanelReminderDraft,
@@ -873,19 +872,6 @@ export function TaskPanel({ tasks }: { tasks: Task[] }) {
             )}
           </div>
         </div>
-
-        {mode === "create" && preFill && (preFill.startAt || preFill.due) && (
-          <div className="flex gap-2 px-4 pb-2 text-xs text-muted-foreground">
-            {preFill.startAt && (
-              <span>
-                {formatTime(new Date(preFill.startAt))}
-                {preFill.endAt &&
-                  `\u2013${formatTime(new Date(preFill.endAt))}`}
-              </span>
-            )}
-            {preFill.allDay === 1 && <span>all day</span>}
-          </div>
-        )}
 
         <div className="grid grid-cols-[4rem_1fr] items-center gap-x-3 gap-y-2 px-4 py-3 border-b border-border/40">
           {mode === "edit" && task && (

--- a/src/lib/calendar-utils.ts
+++ b/src/lib/calendar-utils.ts
@@ -157,6 +157,12 @@ export interface TaskPreFill {
   category?: string;
 }
 
+export interface CreatePreview {
+  dayIndex: number;
+  startMin: number;
+  endMin: number;
+}
+
 export function buildSlotPreFill(date: Date, minuteOfDay: number): TaskPreFill {
   const snapped = Math.round(minuteOfDay / 15) * 15;
   const hours = Math.floor(snapped / 60);
@@ -214,4 +220,28 @@ export function buildDayPreFill(date: Date): TaskPreFill {
     allDay: 1,
     timezone: getUserTimezone(),
   };
+}
+
+export function getCreatePreview(
+  preFill: TaskPreFill | null | undefined,
+  weekAnchor: Date,
+): CreatePreview | null {
+  if (!preFill?.startAt || preFill.allDay) return null;
+
+  const start = new Date(preFill.startAt);
+  const dayIndex = Math.floor(
+    (start.getTime() - weekAnchor.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (dayIndex < 0 || dayIndex > 6) return null;
+
+  const startMin = start.getHours() * 60 + start.getMinutes();
+  let endMin = startMin + 15;
+
+  if (preFill.endAt) {
+    const end = new Date(preFill.endAt);
+    endMin = end.getHours() * 60 + end.getMinutes();
+  }
+
+  return { dayIndex, startMin, endMin };
 }

--- a/tests/lib/calendar-prefill.test.ts
+++ b/tests/lib/calendar-prefill.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildDayPreFill, buildSlotPreFill } from "@/lib/calendar-utils";
+import {
+  buildDayPreFill,
+  buildSlotPreFill,
+  getCreatePreview,
+} from "@/lib/calendar-utils";
 
 describe("buildSlotPreFill", () => {
   it("snaps to nearest 15 minutes", () => {
@@ -95,5 +99,38 @@ describe("buildDayPreFill", () => {
     const date = new Date(2026, 2, 25);
     const result = buildDayPreFill(date);
     expect(result.timezone).toBeTruthy();
+  });
+});
+
+describe("getCreatePreview", () => {
+  it("defaults single-click previews to 15 minutes", () => {
+    const weekAnchor = new Date(2026, 2, 22);
+    const preFill = buildSlotPreFill(new Date(2026, 2, 25), 10 * 60 + 30);
+
+    expect(getCreatePreview(preFill, weekAnchor)).toEqual({
+      dayIndex: 3,
+      startMin: 630,
+      endMin: 645,
+    });
+  });
+
+  it("uses the explicit end time for range-created previews", () => {
+    const weekAnchor = new Date(2026, 2, 22);
+    const date = new Date(2026, 2, 24);
+    const startAt = new Date(date);
+    startAt.setHours(9, 0, 0, 0);
+    const endAt = new Date(date);
+    endAt.setHours(11, 0, 0, 0);
+    const preFill = {
+      startAt: startAt.toISOString(),
+      endAt: endAt.toISOString(),
+      allDay: 0,
+    };
+
+    expect(getCreatePreview(preFill, weekAnchor)).toEqual({
+      dayIndex: 2,
+      startMin: 540,
+      endMin: 660,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make the week-view dashed create preview use the same 15-minute default as the event created from a single slot click
- keep range-created previews aligned with their explicit end time through a shared helper
- remove the create-tray time subtitle under the title so the quick view stays more compact

#### Test plan
- [x] `pnpm exec vitest run tests/lib/calendar-prefill.test.ts`
- [x] `pnpm typecheck`
- [x] `nix develop -c biome check .`