### PR TITLE
fix(reminders): remove custom destination labels from UI

### DIFF
--- a/src/components/settings/reminder-delivery-log-section.tsx
+++ b/src/components/settings/reminder-delivery-log-section.tsx
@@ -7,6 +7,7 @@ import type {
   ReminderAdapterManifest,
   ReminderDeliveryStatus,
 } from "@/core/reminders/types";
+import { getReminderChannelLabel } from "@/lib/reminder-endpoint-form";
 
 function formatTimestamp(value: string | null): string | null {
   if (!value) return null;
@@ -97,10 +98,8 @@ function getDeliveryOutcome(entry: ReminderDeliveryLogEntry): string | null {
 
 function ReminderDeliveryEntry({
   entry,
-  adapterName,
 }: {
   entry: ReminderDeliveryLogRecord;
-  adapterName: string;
 }) {
   const scheduledLabel = formatTimestamp(entry.scheduledFor);
   const outcome = getDeliveryOutcome(entry);
@@ -116,7 +115,7 @@ function ReminderDeliveryEntry({
             </Badge>
           </div>
           <div className="text-xs text-muted-foreground truncate">
-            {adapterName} · {entry.endpoint.label}
+            {getReminderChannelLabel(entry.adapterKey)}
           </div>
           <div className="text-xs text-muted-foreground">
             {formatReminderRule(entry.reminder)} · scheduled {scheduledLabel}
@@ -148,7 +147,7 @@ function ReminderDeliveryEntry({
 
 export function ReminderDeliveryLogSection({
   deliveries,
-  adapters,
+  adapters: _adapters,
 }: {
   deliveries: ReminderDeliveryLogRecord[];
   adapters: ReminderAdapterManifest[];
@@ -157,9 +156,6 @@ export function ReminderDeliveryLogSection({
     (entry) => entry.status === "failed" || entry.status === "dead",
   );
   const recent = deliveries.slice(0, 10);
-  const adapterByKey = new Map(
-    adapters.map((adapter) => [adapter.key, adapter]),
-  );
 
   return (
     <div className="space-y-2">
@@ -172,14 +168,7 @@ export function ReminderDeliveryLogSection({
         </div>
       ) : (
         actionable.map((entry) => (
-          <ReminderDeliveryEntry
-            key={`action-${entry.id}`}
-            entry={entry}
-            adapterName={
-              adapterByKey.get(entry.adapterKey)?.displayName ??
-              entry.adapterKey
-            }
-          />
+          <ReminderDeliveryEntry key={`action-${entry.id}`} entry={entry} />
         ))
       )}
 
@@ -192,14 +181,7 @@ export function ReminderDeliveryLogSection({
         </div>
       ) : (
         recent.map((entry) => (
-          <ReminderDeliveryEntry
-            key={entry.id}
-            entry={entry}
-            adapterName={
-              adapterByKey.get(entry.adapterKey)?.displayName ??
-              entry.adapterKey
-            }
-          />
+          <ReminderDeliveryEntry key={entry.id} entry={entry} />
         ))
       )}
     </div>

--- a/src/components/settings/reminder-endpoints-section.tsx
+++ b/src/components/settings/reminder-endpoints-section.tsx
@@ -13,6 +13,7 @@ import type {
   ReminderAdapterManifest,
 } from "@/core/reminders/types";
 import {
+  getReminderChannelLabel,
   getReminderEndpointAdapterHint,
   getReminderEndpointTargetLabel,
   getReminderEndpointTargetPlaceholder,
@@ -56,23 +57,6 @@ async function parseApiError(response: Response): Promise<string> {
 
 function formatCount(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
-}
-
-function getReminderAdapterLabel(
-  adapter: Pick<ReminderAdapterManifest, "key">,
-): string {
-  switch (adapter.key) {
-    case "sms.twilio":
-      return "SMS";
-    case "whatsapp.twilio":
-      return "WhatsApp";
-    case "telegram.bot_api":
-      return "Telegram";
-    case "slack.webhook":
-      return "Slack";
-    case "discord.webhook":
-      return "Discord";
-  }
 }
 
 function getReminderAdapterDescription(
@@ -185,7 +169,6 @@ export function ReminderEndpointsSection({
   const [deletingTransportKey, setDeletingTransportKey] =
     useState<ReminderTransportConfigurableAdapterKey | null>(null);
   const [endpoints, setEndpoints] = useState(initialEndpoints);
-  const [createLabel, setCreateLabel] = useState("");
   const [createTarget, setCreateTarget] = useState("");
   const [creating, setCreating] = useState(false);
   const [testingIds, setTestingIds] = useState<number[]>([]);
@@ -246,7 +229,6 @@ export function ReminderEndpointsSection({
   }
 
   function resetCreateForm() {
-    setCreateLabel("");
     setCreateTarget("");
   }
 
@@ -346,8 +328,8 @@ export function ReminderEndpointsSection({
   async function handleCreateEndpoint(
     adapterKey: ReminderAdapterManifest["key"],
   ) {
-    if (!createLabel.trim() || !createTarget.trim()) {
-      statusBar.error("destination name and target are required");
+    if (!createTarget.trim()) {
+      statusBar.error("target is required");
       return;
     }
 
@@ -358,7 +340,7 @@ export function ReminderEndpointsSection({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           adapterKey,
-          label: createLabel.trim(),
+          label: getReminderChannelLabel(adapterKey),
           target: createTarget.trim(),
         }),
       });
@@ -517,7 +499,7 @@ export function ReminderEndpointsSection({
                 <div className="min-w-0 space-y-1">
                   <div className="flex items-center gap-2 min-w-0">
                     <span className="text-sm truncate">
-                      {getReminderAdapterLabel(adapter)}
+                      {getReminderChannelLabel(adapterKey)}
                     </span>
                     {adapter.capabilities.beta && (
                       <Badge variant="outline">beta</Badge>
@@ -710,7 +692,9 @@ export function ReminderEndpointsSection({
                               <div className="min-w-0">
                                 <div className="flex items-center gap-2 min-w-0">
                                   <span className="text-sm truncate">
-                                    {endpoint.label}
+                                    {getReminderChannelLabel(
+                                      endpoint.adapterKey,
+                                    )}
                                   </span>
                                   {endpoint.enabled === 0 && (
                                     <Badge variant="ghost">off</Badge>
@@ -769,23 +753,6 @@ export function ReminderEndpointsSection({
 
                     {providerReady && (
                       <div className="space-y-2 border-t border-border/60 pt-3">
-                        <Input
-                          value={createLabel}
-                          onChange={(event) =>
-                            setCreateLabel(event.target.value)
-                          }
-                          placeholder="destination name"
-                          className="h-8 text-sm"
-                          onKeyDown={(event) => {
-                            event.stopPropagation();
-                            if (event.key === "Enter") {
-                              void handleCreateEndpoint(adapterKey);
-                            }
-                            if (event.key === "Escape") {
-                              resetCreateForm();
-                            }
-                          }}
-                        />
                         <Input
                           value={createTarget}
                           onChange={(event) =>

--- a/src/components/task-panel-reminders.tsx
+++ b/src/components/task-panel-reminders.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
 import type { ReminderAnchor } from "@/core/reminders/types";
+import { getReminderChannelLabel } from "@/lib/reminder-endpoint-form";
 import {
   buildReminderOffsetMinutes,
   formatTaskPanelReminderSummary,
@@ -219,8 +220,8 @@ const ReminderEditorRow = memo(function ReminderEditorRow({
               {endpoints.map((endpoint) => (
                 <SelectItem key={endpoint.id} value={String(endpoint.id)}>
                   {endpoint.enabled === 1
-                    ? endpoint.label
-                    : `${endpoint.label} (off)`}
+                    ? getReminderChannelLabel(endpoint.adapterKey)
+                    : `${getReminderChannelLabel(endpoint.adapterKey)} (off)`}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/lib/reminder-endpoint-form.ts
+++ b/src/lib/reminder-endpoint-form.ts
@@ -1,5 +1,22 @@
 import type { ReminderAdapterManifest } from "@/core/reminders/types";
 
+export function getReminderChannelLabel(
+  adapterKey: ReminderAdapterManifest["key"],
+): string {
+  switch (adapterKey) {
+    case "sms.twilio":
+      return "SMS";
+    case "whatsapp.twilio":
+      return "WhatsApp";
+    case "telegram.bot_api":
+      return "Telegram";
+    case "slack.webhook":
+      return "Slack";
+    case "discord.webhook":
+      return "Discord";
+  }
+}
+
 export function getReminderEndpointTargetLabel(
   adapterKey: ReminderAdapterManifest["key"],
 ): string {

--- a/src/lib/task-panel-reminders.ts
+++ b/src/lib/task-panel-reminders.ts
@@ -1,5 +1,6 @@
 import type { ReminderEndpointRecord } from "@/core/reminders/endpoints";
 import type { ReminderAnchor, TaskReminder } from "@/core/reminders/types";
+import { getReminderChannelLabel } from "./reminder-endpoint-form";
 
 export interface TaskPanelReminderDraft {
   clientId: string;
@@ -115,12 +116,18 @@ export function formatTaskPanelReminderSummary(
     TaskPanelReminderDraft,
     "endpointId" | "anchor" | "offsetMinutes" | "allDayLocalTime"
   >,
-  endpoints: Map<number, Pick<ReminderEndpointRecord, "id" | "label">>,
+  endpoints: Map<
+    number,
+    Pick<ReminderEndpointRecord, "id" | "adapterKey" | "label">
+  >,
   options: { allDay: boolean },
 ): string {
   const endpointLabel =
     (reminder.endpointId !== null
-      ? endpoints.get(reminder.endpointId)?.label
+      ? (() => {
+          const endpoint = endpoints.get(reminder.endpointId);
+          return endpoint ? getReminderChannelLabel(endpoint.adapterKey) : null;
+        })()
       : null) ?? "unknown endpoint";
 
   if (options.allDay && reminder.allDayLocalTime) {

--- a/tests/lib/reminder-delivery-log-section.test.ts
+++ b/tests/lib/reminder-delivery-log-section.test.ts
@@ -117,9 +117,10 @@ describe("ReminderDeliveryLogSection", () => {
     expect(html).toContain("next attempt 2026-04-06 15:18 UTC");
     expect(html).toContain("no more retries");
     expect(html).toContain("recent sends");
-    expect(html).toContain("Twilio SMS");
-    expect(html).toContain("Telegram Bot API");
-    expect(html).toContain("Slack Webhook");
+    expect(html).toContain("SMS");
+    expect(html).toContain("Telegram");
+    expect(html).toContain("Slack");
+    expect(html).not.toContain("Phone");
     expect(html).not.toContain("operator playbooks");
   });
 

--- a/tests/lib/task-panel-reminders.test.ts
+++ b/tests/lib/task-panel-reminders.test.ts
@@ -10,8 +10,15 @@ import {
 } from "@/lib/task-panel-reminders";
 
 const endpoints = new Map([
-  [1, { id: 1, label: "personal sms" }],
-  [2, { id: 2, label: "telegram" }],
+  [1, { id: 1, adapterKey: "sms.twilio" as const, label: "personal sms" }],
+  [
+    2,
+    {
+      id: 2,
+      adapterKey: "telegram.bot_api" as const,
+      label: "telegram",
+    },
+  ],
 ]);
 
 describe("task panel reminder helpers", () => {
@@ -71,7 +78,7 @@ describe("task panel reminder helpers", () => {
         endpoints,
         { allDay: false },
       ),
-    ).toBe("1h 30m before due → personal sms");
+    ).toBe("1h 30m before due → SMS");
   });
 
   it("formats all-day reminder summaries with a local time", () => {
@@ -86,7 +93,7 @@ describe("task panel reminder helpers", () => {
         endpoints,
         { allDay: true },
       ),
-    ).toBe("09:00 on due day → telegram");
+    ).toBe("09:00 on due day → Telegram");
   });
 
   it("compares reminder drafts by persisted fields", () => {


### PR DESCRIPTION
## Summary
- remove the custom destination-name field from reminder integrations so setup focuses only on the channel target
- render reminder destinations, picker options, and delivery log metadata using the channel name only
- centralize the visible channel naming in a shared helper so reminder surfaces stay consistent

#### Test plan
- [x] `pnpm exec vitest run tests/lib/task-panel-reminders.test.ts tests/lib/reminder-delivery-log-section.test.ts tests/lib/reminder-endpoints-section.test.ts`
- [x] `pnpm typecheck`
- [x] `nix develop -c biome check src/lib/reminder-endpoint-form.ts src/components/settings/reminder-endpoints-section.tsx src/components/settings/reminder-delivery-log-section.tsx src/lib/task-panel-reminders.ts src/components/task-panel-reminders.tsx tests/lib/task-panel-reminders.test.ts tests/lib/reminder-delivery-log-section.test.ts tests/lib/reminder-endpoints-section.test.ts`