### PR TITLE
fix(settings): remove redundant page eyebrow

### DIFF
--- a/src/components/settings/settings-primitives.tsx
+++ b/src/components/settings/settings-primitives.tsx
@@ -93,13 +93,8 @@ export function SettingsPage({
     <div className={cn("w-full px-4 py-6 md:px-6 md:py-8", className)}>
       {(title || description) && (
         <header className="mb-6 md:mb-8">
-          <div className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground/60">
-            settings
-          </div>
           {title && (
-            <h1 className="mt-2 text-2xl font-semibold tracking-tight">
-              {title}
-            </h1>
+            <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
           )}
           {description && (
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground">

--- a/tests/lib/settings-primitives.test.ts
+++ b/tests/lib/settings-primitives.test.ts
@@ -30,7 +30,6 @@ describe("settings primitives", () => {
       ),
     );
 
-    expect(html).toContain("settings");
     expect(html).toContain("integrations");
     expect(html).toContain("Manage calendar sync and provider API keys.");
     expect(html).toContain("google calendar");


### PR DESCRIPTION
This removes the small grey "settings" label above the main heading across settings pages by simplifying the shared settings page header. The shared primitive test was updated to match the new header output.\n\nVerification: ./scripts/biome.sh check src/components/settings/settings-primitives.tsx tests/lib/settings-primitives.test.ts; PATH=/home/barrett/dev/delta/node_modules/.bin:$PATH vitest --root /home/barrett/dev/delta/.claude/worktrees/fix-remove-settings-eyebrow run settings-primitives