### PR TITLE
chore(release): separate app and cli version flows

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -39,6 +39,12 @@ jobs:
         with:
           node-version: "22"
 
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install CLI dependencies
+        working-directory: cli
+        run: bun install --frozen-lockfile
+
       - name: Install CLI dependencies
         working-directory: cli
         run: bun install --frozen-lockfile
@@ -48,6 +54,10 @@ jobs:
         run: bun run build:local
 
       - name: Build man page
+
+      - name: Build man page
+        working-directory: cli
+        run: bun run build:man
         working-directory: cli
         run: bun run build:man
 
@@ -87,19 +97,15 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Calculate next version
+      - name: Bump CLI version
         id: version
         env:
           VERSION_BUMP: ${{ github.event.inputs.version_bump || 'patch' }}
         run: |
           git fetch origin main --tags
-          NEW_VERSION="$(./scripts/version/next-version.sh cli "$VERSION_BUMP")"
+          NEW_VERSION="$(./scripts/version/bump-cli.sh "$VERSION_BUMP")"
           echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           echo "New version: ${NEW_VERSION}"
-
-      - name: Bump CLI version
-        run: |
-          node -e "const fs=require('fs');const path='cli/package.json';const pkg=JSON.parse(fs.readFileSync(path,'utf8'));pkg.version='${{ steps.version.outputs.new_version }}';fs.writeFileSync(path,JSON.stringify(pkg,null,2)+'\n');"
 
       - name: Configure git
         run: |
@@ -112,7 +118,7 @@ jobs:
           VERSION="${{ steps.version.outputs.new_version }}"
           TAG="cli-v${VERSION}"
 
-          git add cli/package.json
+          git add cli/package.json cli/man/delta.1
 
           if git diff --cached --quiet; then
             echo "No version file changes to commit"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,17 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: Version bump type
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -12,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command biome check .
 
@@ -19,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command pnpm install --frozen-lockfile
       - run: nix develop --command pnpm tsc --noEmit
@@ -27,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command pnpm install --frozen-lockfile
       - run: nix develop --command pnpm vitest run --reporter=verbose --coverage.enabled --coverage.reporter=text
@@ -36,14 +53,65 @@ jobs:
     needs: [lint, typecheck, test]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command pnpm install --frozen-lockfile
       - run: nix develop --command bash scripts/fetch-fonts.sh
       - run: nix develop --command pnpm build
 
+  prepare-release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.CI_PAT }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Bump app version
+        id: version
+        env:
+          VERSION_BUMP: ${{ github.event.inputs.version_bump || 'patch' }}
+        run: |
+          git fetch origin main --tags
+          VERSION="$(./scripts/version/bump-app.sh "$VERSION_BUMP")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Commit and tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+
+          git add package.json
+
+          if git diff --cached --quiet; then
+            echo "No version file changes to commit"
+          else
+            git commit -m "chore(app): release ${TAG} [skip ci]"
+            git fetch origin main --tags
+            git rebase origin/main
+            git push origin HEAD:main
+          fi
+
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}$"; then
+            echo "Tag already exists on origin: ${TAG}"
+          else
+            git tag -a "${TAG}" -m "delta ${TAG}"
+            git push origin "${TAG}"
+          fi
+
   release:
     runs-on: ubuntu-latest
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/cli/man/delta.1
+++ b/cli/man/delta.1
@@ -1,4 +1,4 @@
-.TH "" "1" "April 2026" "0.1.0"
+.TH "" "1" "April 2026" "0.0.2"
 .SH "NAME"
 \fB\fR
 .P
@@ -245,9 +245,7 @@ Regenerate the API token (invalidates the previous token)\.
 .RE
 .SS delta feed
 .P
-iCal subscription management\. Running \fBdelta feed\fP with no verb shows the current subscription
-.br
-URL or status\.
+iCal subscription management\. Running \fBdelta feed\fP with no verb shows the current subscription URL or status\.
 
 .RS 1
 .IP \(bu 2
@@ -820,3 +818,4 @@ $ delta cron run 1
 Project: https://github.com/barrettruth/delta
 .P
 Web interface: https://delta.barrettruth.com
+

--- a/cli/package.json
+++ b/cli/package.json
@@ -33,7 +33,7 @@
     "build": "bun run build.ts",
     "build:local": "bun build src/index.ts --compile --outfile dist/delta",
     "build:npm": "bun build src/index.ts --outfile dist/delta.js --target node && node -e \"const fs=require('fs');const f='dist/delta.js';fs.writeFileSync(f,'#!/usr/bin/env node\\n'+fs.readFileSync(f));fs.chmodSync(f,0o755)\"",
-    "build:man": "npx marked-man man/delta.1.md --version 0.1.0 --section 1 > man/delta.1",
+    "build:man": "npx marked-man man/delta.1.md --version $(node -p \"require('./package.json').version\") --section 1 > man/delta.1",
     "prepublishOnly": "bun run build:man",
     "dev": "bun run src/index.ts"
   },

--- a/scripts/version/bump-app.sh
+++ b/scripts/version/bump-app.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUMP="${1:?Usage: bump-app.sh <patch|minor|major>}"
+VERSION="$(./scripts/version/next-version.sh app "$BUMP")"
+
+node -e "const fs=require('fs');const path='package.json';const pkg=JSON.parse(fs.readFileSync(path,'utf8'));pkg.version='${VERSION}';fs.writeFileSync(path,JSON.stringify(pkg,null,2)+'\n');"
+
+printf '%s\n' "$VERSION"

--- a/scripts/version/bump-cli.sh
+++ b/scripts/version/bump-cli.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUMP="${1:?Usage: bump-cli.sh <patch|minor|major>}"
+VERSION="$(./scripts/version/next-version.sh cli "$BUMP")"
+
+node -e "const fs=require('fs');const path='cli/package.json';const pkg=JSON.parse(fs.readFileSync(path,'utf8'));pkg.version='${VERSION}';fs.writeFileSync(path,JSON.stringify(pkg,null,2)+'\n');"
+
+printf '%s\n' "$VERSION"

--- a/scripts/version/next-version.sh
+++ b/scripts/version/next-version.sh
@@ -5,6 +5,7 @@ PACKAGE="${1:?Usage: next-version.sh <package> <patch|minor|major>}"
 BUMP="${2:?Usage: next-version.sh <package> <patch|minor|major>}"
 
 case "$PACKAGE" in
+  app) PKG_PATH="package.json" ;;
   cli) PKG_PATH="cli/package.json" ;;
   *) echo "Unknown package: $PACKAGE" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
This cleans up version management without coupling the app and CLI into one release line. It adds explicit bump helpers for app and CLI versions, teaches the app release workflow how to prepare a tagged release from main, updates the CLI release workflow to use the CLI bump helper, and removes the hardcoded CLI manpage version so the generated manpage always matches cli/package.json.\n\nLocal validation included the new version scripts, CLI manpage generation, and a full ./scripts/ci.sh run.