### PR TITLE
fix: lowercase kanban sidebar label

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -27,7 +27,7 @@ const VIEW_KEYMAP_IDS: {
   keymapId: string;
 }[] = [
   { label: "Queue", href: "/?view=queue", keymapId: "global.queue" },
-  { label: "Kanban", href: "/kanban", keymapId: "global.kanban" },
+  { label: "kanban", href: "/kanban", keymapId: "global.kanban" },
   { label: "Calendar", href: "/calendar", keymapId: "global.calendar" },
 ];
 

--- a/tests/lib/app-sidebar.test.ts
+++ b/tests/lib/app-sidebar.test.ts
@@ -1,0 +1,105 @@
+import {
+  createElement,
+  type ForwardedRef,
+  forwardRef,
+  type ReactNode,
+} from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { AppSidebar } from "@/components/app-sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/kanban",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/link", () => ({
+  default: forwardRef(function LinkMock(
+    {
+      children,
+      href,
+      ...props
+    }: {
+      children: ReactNode;
+      href: string;
+    },
+    ref: ForwardedRef<HTMLAnchorElement>,
+  ) {
+    return createElement("a", { ...props, href, ref }, children);
+  }),
+}));
+
+vi.mock("@/components/category-color-picker", () => ({
+  CategoryColorPicker: () => createElement("div"),
+}));
+
+vi.mock("@/components/ui/sidebar", () => {
+  function wrap(tag: string) {
+    return ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+      [key: string]: unknown;
+    }) => createElement(tag, props, children);
+  }
+
+  return {
+    Sidebar: wrap("aside"),
+    SidebarContent: wrap("div"),
+    SidebarFooter: wrap("footer"),
+    SidebarGroup: wrap("section"),
+    SidebarGroupContent: wrap("div"),
+    SidebarGroupLabel: wrap("div"),
+    SidebarHeader: wrap("header"),
+    SidebarMenu: wrap("ul"),
+    SidebarMenuItem: wrap("li"),
+    SidebarMenuButton: ({
+      children,
+      render: _render,
+      isActive: _isActive,
+      ...props
+    }: {
+      children?: ReactNode;
+      render?: ReactNode;
+      isActive?: boolean;
+      [key: string]: unknown;
+    }) => createElement("button", { ...props, type: "button" }, children),
+  };
+});
+
+vi.mock("@/contexts/keymaps", () => ({
+  useKeymaps: () => ({
+    getResolvedKeymap: (id: string) => ({
+      triggerKey:
+        {
+          "global.queue": "Q",
+          "global.kanban": "K",
+          "global.calendar": "C",
+          "global.category_jump": "g",
+          "global.settings": "S",
+        }[id] ?? "?",
+    }),
+  }),
+}));
+
+vi.mock("@/contexts/navigation", () => ({
+  useNavigation: () => ({
+    pushJump: () => {},
+  }),
+}));
+
+describe("AppSidebar", () => {
+  it("renders the kanban sidebar label in lowercase", () => {
+    const html = renderToStaticMarkup(
+      createElement(AppSidebar, {
+        username: "barrett",
+        categories: ["work"],
+        categoryColors: {},
+      }),
+    );
+
+    expect(html).toContain("kanban");
+    expect(html).not.toContain("Kanban");
+  });
+});


### PR DESCRIPTION
This makes the sidebar view label for kanban lowercase so it matches the view naming already used elsewhere in the app.

It also adds a small regression test for the rendered sidebar label. Verification ran through ./scripts/ci.sh successfully.