### PR TITLE
fix(queue): keep zero-urgency tasks visible

### DIFF
--- a/src/core/urgency.ts
+++ b/src/core/urgency.ts
@@ -81,6 +81,6 @@ export function rankTasks(
         customWeights,
       ),
     }))
-    .filter((t) => t.urgency > 0)
+    .filter((t) => t.status !== "done" && t.status !== "cancelled")
     .sort((a, b) => b.urgency - a.urgency);
 }

--- a/tests/core/urgency.test.ts
+++ b/tests/core/urgency.test.ts
@@ -148,6 +148,15 @@ describe("rankTasks", () => {
     expect(ranked.every((t) => t.status !== "done")).toBe(true);
   });
 
+  it("keeps active tasks even when urgency is zero", () => {
+    createTask(db, userId, { description: "New pending task" });
+
+    const tasks = listTasks(db, userId);
+    const ranked = rankTasks(db, tasks);
+
+    expect(ranked.map((t) => t.description)).toContain("New pending task");
+  });
+
   it("accounts for blocking relationships", () => {
     const blocker = createTask(db, userId, {
       description: "Blocker",


### PR DESCRIPTION
## Summary
- Keep active queue tasks visible even when their computed urgency is zero or negative.
- Add a regression test for fresh pending tasks in urgency ranking.

Fixes #241

## Tests
- pnpm test tests/core/urgency.test.ts
- ./scripts/biome.sh check src/core/urgency.ts tests/core/urgency.test.ts