### PR TITLE
fix: make all-day and due-only events render like normal events

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -287,16 +287,43 @@ export function CalendarView({
       revert: () => void,
     ) => {
       const meta = isVirtual ? virtualMetaRef.current.get(task.id) : null;
+
+      // A task with only `due` and no `startAt` is rendered on the calendar
+      // as an all-day marker on its deadline. Dragging it in the all-day
+      // row should move the deadline, not silently schedule it (which would
+      // make it disappear from the queue/kanban "due" column). Dropping it
+      // into a timed slot promotes it to a scheduled event and clears `due`.
+      const isDueOnly = !task.startAt && Boolean(task.due);
+      if (isDueOnly && newAllDay) {
+        const dueStr =
+          (task.due as string).length === 10
+            ? newStart.toISOString().slice(0, 10)
+            : newStart.toISOString();
+        pushOptimistic(task.id, {});
+        updateTaskAction(task.id, { due: dueStr }).then((result) => {
+          if ("error" in result) {
+            setOptimisticUpdates((prev) => {
+              const next = new Map(prev);
+              next.delete(task.id);
+              return next;
+            });
+            revert();
+          }
+        });
+        return;
+      }
+
       const startAt = newStart.toISOString();
       const endAt = newEnd ? newEnd.toISOString() : null;
 
       pushOptimistic(task.id, { startAt, endAt });
 
-      const updates = {
+      const updates: Parameters<typeof updateTaskAction>[1] = {
         startAt,
         endAt,
         allDay: newAllDay ? 1 : 0,
       };
+      if (isDueOnly) updates.due = null;
 
       if (meta) {
         recurrenceEdit.requestEdit(meta.masterId, meta.instanceDate, updates);

--- a/src/components/calendar/fc-calendar.tsx
+++ b/src/components/calendar/fc-calendar.tsx
@@ -283,6 +283,7 @@ export const FcCalendar = forwardRef<FcCalendarHandle, FcCalendarProps>(
           expandRows
           height="100%"
           events={events}
+          eventDisplay="block"
           eventContent={renderEventContent}
           eventClick={handleEventClick}
           eventDrop={handleEventDrop}

--- a/src/components/calendar/fc-styles.css
+++ b/src/components/calendar/fc-styles.css
@@ -210,7 +210,7 @@
   align-items: center;
   gap: 2px;
   min-width: 0;
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .fc-delta-title-text {
@@ -308,6 +308,18 @@
   color: var(--foreground);
   padding: 4px 8px;
   font-size: 11px;
+}
+
+/* All-day and month-view events share the same flat block look as timed
+ * events. FullCalendar's daygrid defaults add extra padding and a hover
+ * background to dot-event variants, so normalize both wrappers here. */
+.fc-delta-root .fc .fc-daygrid-dot-event,
+.fc-delta-root .fc .fc-daygrid-block-event {
+  padding: 1px 4px;
+}
+.fc-delta-root .fc .fc-daygrid-dot-event:hover,
+.fc-delta-root .fc .fc-daygrid-dot-event.fc-event-mirror {
+  background: inherit;
 }
 
 /* Ghost draft event shown while the create popover is open. */

--- a/src/lib/fullcalendar-adapter.ts
+++ b/src/lib/fullcalendar-adapter.ts
@@ -53,7 +53,11 @@ function taskToEvent(
   categoryColors: Record<string, string> | undefined,
   isVirtual: boolean,
 ): EventInput | null {
-  if (!task.startAt) return null;
+  // Prefer an explicit scheduled start. Otherwise fall back to `due` and
+  // render the task as an all-day marker on its deadline day. Tasks with
+  // neither a start nor a due date never appear on the calendar.
+  const isDueOnly = !task.startAt && Boolean(task.due);
+  if (!task.startAt && !isDueOnly) return null;
 
   const isRecurring = Boolean(task.recurrence) || Boolean(task.recurringTaskId);
   const classNames: string[] = [`status-${task.status ?? "pending"}`];
@@ -63,17 +67,29 @@ function taskToEvent(
   const color =
     task.category && categoryColors ? categoryColors[task.category] : undefined;
 
+  // For due-only tasks: a `YYYY-MM-DD` string is a pure date (all-day). A full
+  // ISO timestamp still has a time component but with no duration, so we pin
+  // it to the day and mark it all-day so FC shows it in the all-day row.
+  const dueStart = isDueOnly
+    ? (task.due as string).length === 10
+      ? (task.due as string)
+      : (task.due as string).slice(0, 10)
+    : undefined;
+
   const event: EventInput = {
     id: String(task.id),
     title: task.description,
-    start: task.startAt,
-    end: task.endAt ?? undefined,
-    allDay: task.allDay === 1,
+    start: isDueOnly ? (dueStart as string) : (task.startAt as string),
+    end: isDueOnly ? undefined : (task.endAt ?? undefined),
+    allDay: isDueOnly ? true : task.allDay === 1,
+    editable: true,
+    durationEditable: !isDueOnly,
     classNames,
     extendedProps: {
       task,
       isVirtual,
       isRecurring,
+      isDueOnly,
     },
   };
 
@@ -140,7 +156,7 @@ export function tasksToEvents(
       continue;
     }
 
-    if (!task.startAt) continue;
+    if (!task.startAt && !task.due) continue;
     if (optimisticUpdates?.get(task.id)?.deleted) continue;
 
     const merged = mergeTask(task, pendingEdits, optimisticUpdates);


### PR DESCRIPTION
## Summary

All-day events (including deadline-only tasks rendered in the all-day row) were showing with a dashed border, transparent background, and a hourglass prefix next to scheduled events.
it was ugly

- Drops the `.is-due` styling + class so due-only tasks render with the same solid block + left border as any other event.
- Sets `eventDisplay="block"` on the FullCalendar instance so month/daygrid views stop using the dot-event variant.
- Normalizes leftover daygrid wrapper padding and neutralizes its hover background.
- Tightens the drag path for due-only tasks: dropping in the all-day row updates `due`; dropping in a timed slot promotes it and clears `due`.