### PR TITLE
fix: taskpanel savetask fix

### DIFF
--- a/src/components/task-panel.tsx
+++ b/src/components/task-panel.tsx
@@ -131,6 +131,12 @@ export function TaskPanel({
   const pendingYRef = useRef(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const prevTaskIdRef = useRef<number | null>(null);
+  // Snapshot of the `due` input value when the form loaded for this task.
+  // Used to skip rewriting `due` on save when the user didn't touch it —
+  // otherwise the round-trip through `new Date(datetime-local).toISOString()`
+  // shifts the stored timestamp by the local timezone offset, which can
+  // push an all-day / due-only event onto the adjacent date.
+  const initialDueRef = useRef<string>("");
   const reminderClientIdRef = useRef(0);
   const reminderDraftsRef = useRef<TaskPanelReminderDraft[]>([]);
   const initialReminderDraftsRef = useRef<TaskPanelReminderDraft[]>([]);
@@ -544,10 +550,13 @@ export function TaskPanel({
       const currentReminderDrafts = cloneReminderDrafts(
         reminderDraftsRef.current,
       );
+      const dueChanged = f.due !== initialDueRef.current;
       const result = await updateTaskAction(id, {
         description: f.description,
         category: f.category || null,
-        due: f.due ? new Date(f.due).toISOString() : null,
+        ...(dueChanged
+          ? { due: f.due ? new Date(f.due).toISOString() : null }
+          : {}),
         notes: f.notes || null,
         location: f.location || null,
         locationLat: f.location ? f.locationLat : null,
@@ -591,7 +600,9 @@ export function TaskPanel({
     if (mode === "edit" && t) {
       setDescription(t.description);
       setCategory(t.category ?? "");
-      setDue(t.due ? t.due.slice(0, t.allDay === 1 ? 10 : 16) : "");
+      const dueInit = t.due ? t.due.slice(0, t.allDay === 1 ? 10 : 16) : "";
+      setDue(dueInit);
+      initialDueRef.current = dueInit;
       setLocation(t.location ?? "");
       setLocationLat(t.locationLat ?? null);
       setLocationLon(t.locationLon ?? null);
@@ -602,11 +613,11 @@ export function TaskPanel({
     } else if (mode === "create") {
       setDescription("");
       setCategory(preFill?.category ?? "");
-      setDue(
-        preFill?.startAt
-          ? preFill.startAt.slice(0, preFill?.allDay === 1 ? 10 : 16)
-          : "",
-      );
+      const dueInit = preFill?.startAt
+        ? preFill.startAt.slice(0, preFill?.allDay === 1 ? 10 : 16)
+        : "";
+      setDue(dueInit);
+      initialDueRef.current = dueInit;
       setLocation("");
       setLocationLat(null);
       setLocationLon(null);


### PR DESCRIPTION
Root cause: 

In task-panel.tsx's saveTask, the due field is always
re-sent on every save — including the implicit save that fires on
popover close (the cleanup effect at useEffect(... if (!isOpen)
return; return () => void saveTask(id) ...)).

The due value in the form starts as t.due.slice(0, 16) — a string
like "2026-04-20T00:00" with no timezone suffix. On save it
round-trips through:

due: f.due ? new Date(f.due).toISOString() : null

Fix:

(src/components/task-panel.tsx)

• Snapshot the initial due string in initialDueRef when the form
loads (both edit and create modes).
• In saveTask, only include due in the update payload if the form
value actually differs from that snapshot.

Explanation:

This way, opening and closing the popover without touching the date
field is a no-op for due, so the event stays put. Real user edits to
due still go through normally.
