### PR TITLE
fix: make task panel saves atomic

### DIFF
--- a/src/app/actions/tasks.ts
+++ b/src/app/actions/tasks.ts
@@ -19,6 +19,7 @@ import {
   getTask,
   updateTask,
 } from "@/core/task";
+import { saveTaskDetails } from "@/core/task-detail-save";
 import type {
   CreateTaskInput,
   Task,
@@ -28,6 +29,7 @@ import type {
 import { db } from "@/db";
 import { categoryColors, tasks } from "@/db/schema";
 import { getAuthUser } from "@/lib/auth-middleware";
+import type { TaskPanelReminderDraft } from "@/lib/task-panel-reminders";
 
 type ActionResult<T> = { data: T } | { error: string };
 
@@ -69,6 +71,25 @@ export async function updateTaskAction(
     return { data: task };
   } catch (e) {
     return { error: e instanceof Error ? e.message : "Failed to update task" };
+  }
+}
+
+export async function saveTaskDetailsAction(
+  id: number,
+  input: {
+    task: UpdateTaskInput;
+    reminders?: TaskPanelReminderDraft[] | null;
+  },
+): Promise<ActionResult<ReturnType<typeof saveTaskDetails>>> {
+  try {
+    const { user } = await requireOwnedTask(id);
+    const result = saveTaskDetails(db, user.id, id, input);
+    revalidatePath("/", "layout");
+    return { data: result };
+  } catch (e) {
+    return {
+      error: e instanceof Error ? e.message : "Failed to save task details",
+    };
   }
 }
 

--- a/src/components/task-panel.tsx
+++ b/src/components/task-panel.tsx
@@ -6,6 +6,7 @@ import {
   completeTaskAction,
   createTaskAction,
   deleteTaskAction,
+  saveTaskDetailsAction,
   updateTaskAction,
 } from "@/app/actions/tasks";
 import { RecurrenceStrategyDialog } from "@/components/recurrence-strategy-dialog";
@@ -39,6 +40,13 @@ import {
   taskPanelRemindersEqual,
   taskReminderToDraft,
 } from "@/lib/task-panel-reminders";
+import {
+  buildTaskPanelUpdateInput,
+  isTaskPanelDirty,
+  mergeSavedReminderDrafts,
+  type TaskPanelFormValues,
+  taskPanelRemindersChanged,
+} from "@/lib/task-panel-save";
 import { detectMeetingPlatform } from "@/lib/utils";
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
@@ -97,10 +105,12 @@ export function TaskPanel({
     taskId,
     preFill,
     width,
+    closeRequestSeq,
     optimisticTasks,
     setPendingEdit,
     clearPendingEdit,
     clearOptimisticTask,
+    forceClose,
   } = panel;
 
   const task = useMemo(
@@ -145,6 +155,7 @@ export function TaskPanel({
   const [locationIdx, setLocationIdx] = useState(-1);
   const [recurrenceFocused, setRecurrenceFocused] = useState(false);
   const notesRef = useRef<string | null>(null);
+  const [notesValue, setNotesValue] = useState<string | null>(null);
   const pendingYRef = useRef(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const prevTaskIdRef = useRef<number | null>(null);
@@ -157,6 +168,10 @@ export function TaskPanel({
   const reminderClientIdRef = useRef(0);
   const reminderDraftsRef = useRef<TaskPanelReminderDraft[]>([]);
   const initialReminderDraftsRef = useRef<TaskPanelReminderDraft[]>([]);
+  const initialFormRef = useRef<TaskPanelFormValues | null>(null);
+  const saveQueueRef = useRef(Promise.resolve(true));
+  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handledCloseRequestRef = useRef(0);
   const remindersReadyRef = useRef(false);
 
   const [reminderEndpoints, setReminderEndpoints] = useState<
@@ -223,6 +238,7 @@ export function TaskPanel({
 
   const handleNotesChange = useCallback((json: string) => {
     notesRef.current = json;
+    setNotesValue(json);
   }, []);
 
   const loadReminderState = useCallback(
@@ -563,66 +579,168 @@ export function TaskPanel({
 
   const { results: locationResults } = useLocationSearch(location);
 
+  const getCurrentFormValues = useCallback(
+    (): TaskPanelFormValues => ({
+      ...formDataRef.current,
+    }),
+    [],
+  );
+
+  const currentFormValues = useMemo(
+    (): TaskPanelFormValues => ({
+      description,
+      category,
+      due,
+      location,
+      locationLat,
+      locationLon,
+      meetingUrl,
+      recurrence,
+      recurMode,
+      notes: notesValue,
+    }),
+    [
+      description,
+      category,
+      due,
+      location,
+      locationLat,
+      locationLon,
+      meetingUrl,
+      recurrence,
+      recurMode,
+      notesValue,
+    ],
+  );
+
+  const clearAutoSaveTimer = useCallback(() => {
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current);
+      autoSaveTimerRef.current = null;
+    }
+  }, []);
+
   const saveTask = useCallback(
-    async (id: number, options?: { applyReminderState?: boolean }) => {
-      const f = formDataRef.current;
-      const initialReminderDrafts = cloneReminderDrafts(
-        initialReminderDraftsRef.current,
-      );
-      const currentReminderDrafts = cloneReminderDrafts(
-        reminderDraftsRef.current,
-      );
-      const dueChanged = f.due !== initialDueRef.current;
-      const result = await updateTaskAction(id, {
-        description: f.description,
-        category: f.category || null,
-        ...(dueChanged
-          ? { due: f.due ? new Date(f.due).toISOString() : null }
-          : {}),
-        notes: f.notes || null,
-        location: f.location || null,
-        locationLat: f.location ? f.locationLat : null,
-        locationLon: f.location ? f.locationLon : null,
-        meetingUrl: f.meetingUrl || null,
-        recurrence: f.recurrence || null,
-        recurMode: f.recurrence ? f.recurMode : null,
-      });
+    (
+      id: number,
+      options?: { applyReminderState?: boolean; includeReminders?: boolean },
+    ) => {
+      const snapshot = {
+        form: getCurrentFormValues(),
+        reminders:
+          options?.includeReminders && remindersReadyRef.current
+            ? cloneReminderDrafts(reminderDraftsRef.current)
+            : null,
+        initialDue: initialDueRef.current,
+      };
 
-      if ("error" in result) {
-        statusBar.error(result.error);
-        return false;
-      }
+      const run = async () => {
+        const initialReminders = snapshot.reminders
+          ? cloneReminderDrafts(initialReminderDraftsRef.current)
+          : null;
 
-      try {
-        await saveTaskReminders(id, {
-          initial: initialReminderDrafts,
-          current: currentReminderDrafts,
-          applyState: options?.applyReminderState,
+        if (
+          !isTaskPanelDirty(
+            initialFormRef.current,
+            snapshot.form,
+            initialReminders,
+            snapshot.reminders,
+          )
+        ) {
+          return true;
+        }
+
+        const result = await saveTaskDetailsAction(id, {
+          task: buildTaskPanelUpdateInput(snapshot.form, snapshot.initialDue),
+          ...(snapshot.reminders ? { reminders: snapshot.reminders } : {}),
         });
-      } catch (error) {
-        statusBar.error(
-          error instanceof Error ? error.message : "Failed to save reminders",
-        );
-        return false;
-      }
 
-      return true;
+        if ("error" in result) {
+          statusBar.error(result.error);
+          return false;
+        }
+
+        initialFormRef.current = snapshot.form;
+        initialDueRef.current = snapshot.form.due;
+
+        if (snapshot.reminders) {
+          const savedDrafts = mergeSavedReminderDrafts(
+            snapshot.reminders,
+            result.data.reminders,
+          );
+          initialReminderDraftsRef.current = savedDrafts;
+
+          if (
+            options?.applyReminderState !== false &&
+            panelOpenRef.current &&
+            activeTaskIdRef.current === id
+          ) {
+            setReminderDrafts((current) => {
+              const mergedIds = current.map((draft) => {
+                const saved = savedDrafts.find(
+                  (candidate) => candidate.clientId === draft.clientId,
+                );
+
+                if (!saved || draft.id !== null || saved.id === null) {
+                  return draft;
+                }
+
+                return { ...draft, id: saved.id };
+              });
+              const nextDrafts = taskPanelRemindersChanged(
+                snapshot.reminders,
+                mergedIds,
+              )
+                ? mergedIds
+                : savedDrafts;
+              reminderDraftsRef.current = nextDrafts;
+              return nextDrafts;
+            });
+          }
+        }
+
+        return true;
+      };
+
+      const queued = saveQueueRef.current.then(run, run);
+      saveQueueRef.current = queued.then(
+        () => true,
+        () => true,
+      );
+
+      return queued;
     },
-    [saveTaskReminders, statusBar],
+    [getCurrentFormValues, statusBar],
   );
 
   useEffect(() => {
     const prevId = prevTaskIdRef.current;
     if (prevId && prevId !== taskId) {
-      void saveTask(prevId, { applyReminderState: false });
+      void saveTask(prevId, {
+        applyReminderState: false,
+        includeReminders: true,
+      });
     }
     prevTaskIdRef.current = taskId;
 
     const t = taskRef.current;
     if (mode === "edit" && t) {
+      const dueInit = t.due ? t.due.slice(0, t.allDay === 1 ? 10 : 16) : "";
+      const nextForm = {
+        description: t.description,
+        category: t.category ?? "",
+        due: dueInit,
+        location: t.location ?? "",
+        locationLat: t.locationLat ?? null,
+        locationLon: t.locationLon ?? null,
+        meetingUrl: t.meetingUrl ?? "",
+        recurrence: t.recurrence,
+        recurMode: t.recurMode ?? "scheduled",
+        notes: t.notes ?? null,
+      } satisfies TaskPanelFormValues;
+      initialFormRef.current = nextForm;
       setDescription(t.description);
       setCategory(t.category ?? "");
-      const dueInit = t.due ? t.due.slice(0, t.allDay === 1 ? 10 : 16) : "";
       setDue(dueInit);
       initialDueRef.current = dueInit;
       setLocation(t.location ?? "");
@@ -632,12 +750,25 @@ export function TaskPanel({
       setRecurrence(t.recurrence);
       setRecurMode(t.recurMode ?? "scheduled");
       notesRef.current = t.notes ?? null;
+      setNotesValue(t.notes ?? null);
     } else if (mode === "create") {
-      setDescription("");
-      setCategory(preFill?.category ?? "");
       const dueInit = preFill?.startAt
         ? preFill.startAt.slice(0, preFill?.allDay === 1 ? 10 : 16)
         : "";
+      initialFormRef.current = {
+        description: "",
+        category: preFill?.category ?? "",
+        due: dueInit,
+        location: "",
+        locationLat: null,
+        locationLon: null,
+        meetingUrl: "",
+        recurrence: null,
+        recurMode: "scheduled",
+        notes: null,
+      };
+      setDescription("");
+      setCategory(preFill?.category ?? "");
       setDue(dueInit);
       initialDueRef.current = dueInit;
       setLocation("");
@@ -647,6 +778,7 @@ export function TaskPanel({
       setRecurrence(null);
       setRecurMode("scheduled");
       notesRef.current = null;
+      setNotesValue(null);
     }
   }, [taskId, mode, preFill, saveTask]);
 
@@ -664,15 +796,6 @@ export function TaskPanel({
       nav.setTaskDetailOpen(null);
     }
   }, [isOpen, taskId, nav]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    return () => {
-      const id = prevTaskIdRef.current;
-      if (id) void saveTask(id, { applyReminderState: false });
-      prevTaskIdRef.current = null;
-    };
-  }, [isOpen, saveTask]);
 
   const handleCreate = useCallback(async () => {
     const trimmed = description.trim();
@@ -715,7 +838,7 @@ export function TaskPanel({
             : "task created, but reminders failed to save",
         );
       }
-      panel.close();
+      forceClose();
       return;
     }
 
@@ -733,7 +856,7 @@ export function TaskPanel({
     recurrence,
     recurMode,
     preFill,
-    panel,
+    forceClose,
     saveTaskReminders,
     statusBar,
   ]);
@@ -753,7 +876,7 @@ export function TaskPanel({
       (task.recurrence || task.recurringTaskId) &&
       recurrenceDelete.requestDelete(task)
     ) {
-      panel.close();
+      forceClose();
       return;
     }
     undo.push({
@@ -773,8 +896,8 @@ export function TaskPanel({
     });
     prevTaskIdRef.current = null;
     deleteTaskAction(task.id);
-    panel.close();
-  }, [task, recurrenceDelete, undo, panel]);
+    forceClose();
+  }, [task, recurrenceDelete, undo, forceClose]);
 
   const handleShare = useCallback(async () => {
     if (!task?.startAt) return;
@@ -794,12 +917,46 @@ export function TaskPanel({
     }
   }, [task, statusBar]);
 
+  const handleClosePanel = useCallback(async () => {
+    clearAutoSaveTimer();
+
+    if (mode === "edit" && task) {
+      if (
+        await saveTask(task.id, {
+          applyReminderState: false,
+          includeReminders: true,
+        })
+      ) {
+        forceClose();
+      }
+      return;
+    }
+
+    if (mode === "create") {
+      if (description.trim()) {
+        await handleCreate();
+      } else {
+        forceClose();
+      }
+    }
+  }, [
+    clearAutoSaveTimer,
+    mode,
+    task,
+    saveTask,
+    forceClose,
+    description,
+    handleCreate,
+  ]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (keymaps.resolvedMatchesEvent("task_detail.save", e.nativeEvent)) {
         e.preventDefault();
-        if (mode === "edit" && task) void saveTask(task.id);
-        else if (mode === "create") void handleCreate();
+        clearAutoSaveTimer();
+        if (mode === "edit" && task) {
+          void saveTask(task.id, { includeReminders: true });
+        } else if (mode === "create") void handleCreate();
         return;
       }
 
@@ -808,16 +965,7 @@ export function TaskPanel({
       if (e.key === closeKey) {
         e.preventDefault();
         e.stopPropagation();
-        if (mode === "edit" && task) {
-          void saveTask(task.id, { applyReminderState: false });
-          panel.close();
-        } else if (mode === "create") {
-          if (description.trim()) {
-            void handleCreate();
-          } else {
-            panel.close();
-          }
-        }
+        void handleClosePanel();
         return;
       }
 
@@ -857,24 +1005,60 @@ export function TaskPanel({
       mode,
       task,
       saveTask,
-      panel,
+      clearAutoSaveTimer,
+      handleClosePanel,
       handleCreate,
       handleShare,
-      description,
       keymaps,
     ],
   );
 
   useEffect(() => {
     if (isOpen && mode === "edit" && !task) {
-      panel.close();
+      forceClose();
     }
-  }, [isOpen, mode, task, panel]);
+  }, [isOpen, mode, task, forceClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      handledCloseRequestRef.current = closeRequestSeq;
+      return;
+    }
+    if (closeRequestSeq === handledCloseRequestRef.current) return;
+    handledCloseRequestRef.current = closeRequestSeq;
+    void handleClosePanel();
+  }, [closeRequestSeq, handleClosePanel, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || mode !== "edit" || !task) {
+      clearAutoSaveTimer();
+      return;
+    }
+
+    if (currentFormValues.description.trim().length === 0) {
+      clearAutoSaveTimer();
+      return;
+    }
+
+    if (
+      !isTaskPanelDirty(initialFormRef.current, currentFormValues, null, null)
+    ) {
+      clearAutoSaveTimer();
+      return;
+    }
+
+    autoSaveTimerRef.current = setTimeout(() => {
+      void saveTask(task.id);
+    }, 750);
+
+    return clearAutoSaveTimer;
+  }, [isOpen, mode, task, clearAutoSaveTimer, currentFormValues, saveTask]);
 
   useEffect(() => {
     async function onSave() {
       if (mode === "edit" && task) {
-        if (await saveTask(task.id)) {
+        clearAutoSaveTimer();
+        if (await saveTask(task.id, { includeReminders: true })) {
           statusBar.message("saved");
         }
       } else if (mode === "create") {
@@ -883,7 +1067,8 @@ export function TaskPanel({
     }
     function onDiscard() {
       prevTaskIdRef.current = null;
-      panel.close();
+      clearAutoSaveTimer();
+      forceClose();
     }
     window.addEventListener("command-save-task", onSave);
     window.addEventListener("command-discard-task", onDiscard);
@@ -891,7 +1076,15 @@ export function TaskPanel({
       window.removeEventListener("command-save-task", onSave);
       window.removeEventListener("command-discard-task", onDiscard);
     };
-  }, [mode, task, saveTask, handleCreate, panel, statusBar]);
+  }, [
+    mode,
+    task,
+    saveTask,
+    handleCreate,
+    forceClose,
+    statusBar,
+    clearAutoSaveTimer,
+  ]);
 
   const isMobile = useIsMobile();
 
@@ -918,12 +1111,7 @@ export function TaskPanel({
             <button
               type="button"
               className="text-xs text-muted-foreground hover:text-foreground mb-2 min-h-[44px] flex items-center"
-              onClick={() => {
-                if (mode === "edit" && task) {
-                  void saveTask(task.id, { applyReminderState: false });
-                }
-                panel.close();
-              }}
+              onClick={() => void handleClosePanel()}
             >
               &larr; back
             </button>
@@ -961,18 +1149,7 @@ export function TaskPanel({
               type="button"
               aria-label="close task panel"
               className="text-muted-foreground hover:text-foreground shrink-0 p-1 border border-border hover:border-foreground/30 transition-colors cursor-pointer"
-              onClick={() => {
-                if (mode === "edit" && task) {
-                  void saveTask(task.id, { applyReminderState: false });
-                  panel.close();
-                } else if (mode === "create") {
-                  if (description.trim()) {
-                    void handleCreate();
-                  } else {
-                    panel.close();
-                  }
-                }
-              }}
+              onClick={() => void handleClosePanel()}
             >
               <X size={14} />
             </button>
@@ -1207,7 +1384,7 @@ export function TaskPanel({
         mode="delete"
         onSelect={(strategy) => {
           recurrenceDelete.executeStrategy(strategy);
-          panel.close();
+          forceClose();
         }}
       />
     </>

--- a/src/contexts/task-panel.tsx
+++ b/src/contexts/task-panel.tsx
@@ -19,11 +19,13 @@ interface TaskPanelContextValue {
   taskId: number | null;
   preFill: TaskPreFill | null;
   width: number;
+  closeRequestSeq: number;
   pendingEdits: Map<number, Partial<Task>>;
   optimisticTasks: Map<number, Task>;
   open: (taskId: number) => void;
   create: (preFill?: TaskPreFill) => void;
   close: () => void;
+  forceClose: () => void;
   toggle: (taskId: number) => void;
   setWidth: (w: number) => void;
   setPendingEdit: (taskId: number, fields: Partial<Task>) => void;
@@ -44,6 +46,7 @@ export function TaskPanelProvider({ children }: { children: React.ReactNode }) {
   const [mode, setMode] = useState<PanelMode>("edit");
   const [taskId, setTaskId] = useState<number | null>(null);
   const [preFill, setPreFill] = useState<TaskPreFill | null>(null);
+  const [closeRequestSeq, setCloseRequestSeq] = useState(0);
   const [pendingEdits, setPendingEdits] = useState<Map<number, Partial<Task>>>(
     () => new Map(),
   );
@@ -82,7 +85,7 @@ export function TaskPanelProvider({ children }: { children: React.ReactNode }) {
     setIsOpen(true);
   }, []);
 
-  const close = useCallback(() => {
+  const forceClose = useCallback(() => {
     const id = taskIdRef.current;
     if (id !== null) {
       setPendingEdits((prev) => {
@@ -102,9 +105,14 @@ export function TaskPanelProvider({ children }: { children: React.ReactNode }) {
     setPreFill(null);
   }, []);
 
+  const close = useCallback(() => {
+    if (!isOpenRef.current) return;
+    setCloseRequestSeq((prev) => prev + 1);
+  }, []);
+
   const toggle = useCallback((id: number) => {
     if (isOpenRef.current && taskIdRef.current === id) {
-      setIsOpen(false);
+      setCloseRequestSeq((prev) => prev + 1);
     } else {
       setTaskId(id);
       setMode("edit");
@@ -161,11 +169,13 @@ export function TaskPanelProvider({ children }: { children: React.ReactNode }) {
       taskId,
       preFill,
       width,
+      closeRequestSeq,
       pendingEdits,
       optimisticTasks,
       open,
       create,
       close,
+      forceClose,
       toggle,
       setWidth,
       setPendingEdit,
@@ -179,11 +189,13 @@ export function TaskPanelProvider({ children }: { children: React.ReactNode }) {
       taskId,
       preFill,
       width,
+      closeRequestSeq,
       pendingEdits,
       optimisticTasks,
       open,
       create,
       close,
+      forceClose,
       toggle,
       setWidth,
       setPendingEdit,

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -129,7 +129,6 @@ export const commandRegistry: CommandDefinition[] = [
     execute: (_args, ctx) => {
       if (ctx.taskPanel.isOpen) {
         ctx.discardTask();
-        ctx.taskPanel.close();
       } else {
         ctx.logout();
       }
@@ -150,7 +149,6 @@ export const commandRegistry: CommandDefinition[] = [
     category: "task",
     expectedArgs: [],
     execute: (_args, ctx) => {
-      ctx.saveTask();
       ctx.taskPanel.close();
     },
   },

--- a/src/core/task-detail-save.ts
+++ b/src/core/task-detail-save.ts
@@ -1,0 +1,134 @@
+import type { TaskPanelReminderDraft } from "@/lib/task-panel-reminders";
+import { taskPanelRemindersEqual } from "@/lib/task-panel-reminders";
+import { getReminderEndpoint } from "./reminders/endpoints";
+import {
+  createTaskReminder,
+  deleteTaskReminder,
+  listTaskReminders,
+  updateTaskReminder,
+} from "./reminders/rules";
+import type { TaskReminder } from "./reminders/types";
+import { getTask, updateTask } from "./task";
+import type { Db, Task, UpdateTaskInput } from "./types";
+
+interface SaveTaskDetailsInput {
+  task: UpdateTaskInput;
+  reminders?: TaskPanelReminderDraft[] | null;
+}
+
+interface SaveTaskDetailsResult {
+  task: Task;
+  reminders: TaskReminder[];
+}
+
+function syncTaskReminders(
+  db: Db,
+  userId: number,
+  taskId: number,
+  reminders: TaskPanelReminderDraft[],
+): TaskReminder[] {
+  const existing = listTaskReminders(db, userId, taskId);
+  const existingById = new Map(
+    existing.map((reminder) => [reminder.id, reminder]),
+  );
+  const nextIds = new Set<number>();
+
+  for (const reminder of reminders) {
+    if (reminder.id !== null) {
+      if (nextIds.has(reminder.id)) {
+        throw new Error(`Task reminder ${reminder.id} is duplicated`);
+      }
+      nextIds.add(reminder.id);
+    }
+
+    if (reminder.endpointId === null) {
+      throw new Error("Reminder endpoint is required");
+    }
+
+    const endpoint = getReminderEndpoint(db, userId, reminder.endpointId);
+    if (!endpoint) {
+      throw new Error("Reminder endpoint not found");
+    }
+  }
+
+  for (const reminder of existing) {
+    if (!nextIds.has(reminder.id)) {
+      deleteTaskReminder(db, userId, reminder.id);
+    }
+  }
+
+  return reminders.map((reminder) => {
+    if (reminder.endpointId === null) {
+      throw new Error("Reminder endpoint is required");
+    }
+
+    if (reminder.id === null) {
+      return createTaskReminder(db, userId, {
+        taskId,
+        endpointId: reminder.endpointId,
+        anchor: reminder.anchor,
+        offsetMinutes: reminder.offsetMinutes,
+        allDayLocalTime: reminder.allDayLocalTime,
+        enabled: reminder.enabled,
+      });
+    }
+
+    const existingReminder = existingById.get(reminder.id);
+    if (!existingReminder) {
+      throw new Error(`Task reminder ${reminder.id} not found`);
+    }
+
+    if (
+      taskPanelRemindersEqual(
+        {
+          id: existingReminder.id,
+          endpointId: existingReminder.endpointId,
+          anchor: existingReminder.anchor,
+          offsetMinutes: existingReminder.offsetMinutes,
+          allDayLocalTime: existingReminder.allDayLocalTime,
+          enabled: existingReminder.enabled === 1 ? 1 : 0,
+        },
+        reminder,
+      )
+    ) {
+      return existingReminder;
+    }
+
+    const updated = updateTaskReminder(db, userId, reminder.id, {
+      endpointId: reminder.endpointId,
+      anchor: reminder.anchor,
+      offsetMinutes: reminder.offsetMinutes,
+      allDayLocalTime: reminder.allDayLocalTime,
+      enabled: reminder.enabled,
+    });
+
+    if (!updated) {
+      throw new Error(`Task reminder ${reminder.id} not found`);
+    }
+
+    return updated;
+  });
+}
+
+export function saveTaskDetails(
+  db: Db,
+  userId: number,
+  taskId: number,
+  input: SaveTaskDetailsInput,
+): SaveTaskDetailsResult {
+  const existingTask = getTask(db, taskId);
+  if (!existingTask || existingTask.userId !== userId) {
+    throw new Error("Task not found");
+  }
+
+  return db.transaction((tx) => {
+    const txDb = tx as Db;
+    const task = updateTask(txDb, taskId, input.task);
+    const reminders =
+      input.reminders === undefined || input.reminders === null
+        ? listTaskReminders(txDb, userId, taskId)
+        : syncTaskReminders(txDb, userId, taskId, input.reminders);
+
+    return { task, reminders };
+  });
+}

--- a/src/lib/task-panel-save.ts
+++ b/src/lib/task-panel-save.ts
@@ -1,0 +1,108 @@
+import type { TaskReminder } from "@/core/reminders/types";
+import type { UpdateTaskInput } from "@/core/types";
+import {
+  type TaskPanelReminderDraft,
+  taskPanelRemindersEqual,
+  taskReminderToDraft,
+} from "./task-panel-reminders";
+
+export interface TaskPanelFormValues {
+  description: string;
+  category: string;
+  due: string;
+  location: string;
+  locationLat: number | null;
+  locationLon: number | null;
+  meetingUrl: string;
+  recurrence: string | null;
+  recurMode: "scheduled" | "completion";
+  notes: string | null;
+}
+
+export function normalizeTaskPanelFormValues(
+  values: TaskPanelFormValues,
+): TaskPanelFormValues {
+  return {
+    ...values,
+    description: values.description.trim(),
+    location: values.location.trim(),
+    meetingUrl: values.meetingUrl.trim(),
+    recurrence: values.recurrence || null,
+  };
+}
+
+export function buildTaskPanelUpdateInput(
+  values: TaskPanelFormValues,
+  initialDue: string,
+): UpdateTaskInput {
+  const normalized = normalizeTaskPanelFormValues(values);
+
+  return {
+    description: normalized.description,
+    category: normalized.category || null,
+    ...(normalized.due !== initialDue
+      ? { due: normalized.due ? new Date(normalized.due).toISOString() : null }
+      : {}),
+    notes: normalized.notes || null,
+    location: normalized.location || null,
+    locationLat: normalized.location ? normalized.locationLat : null,
+    locationLon: normalized.location ? normalized.locationLon : null,
+    meetingUrl: normalized.meetingUrl || null,
+    recurrence: normalized.recurrence || null,
+    recurMode: normalized.recurrence ? normalized.recurMode : null,
+  };
+}
+
+export function taskPanelRemindersChanged(
+  initial: TaskPanelReminderDraft[] | null,
+  current: TaskPanelReminderDraft[] | null,
+): boolean {
+  if (!initial || !current) return false;
+  if (initial.length !== current.length) return true;
+
+  return initial.some((reminder, index) => {
+    const next = current[index];
+    if (!next) return true;
+
+    return !taskPanelRemindersEqual(reminder, next);
+  });
+}
+
+export function isTaskPanelDirty(
+  initial: TaskPanelFormValues | null,
+  current: TaskPanelFormValues,
+  initialReminders: TaskPanelReminderDraft[] | null,
+  currentReminders: TaskPanelReminderDraft[] | null,
+): boolean {
+  if (!initial) return false;
+
+  const normalizedInitial = normalizeTaskPanelFormValues(initial);
+  const normalizedCurrent = normalizeTaskPanelFormValues(current);
+
+  return (
+    normalizedInitial.description !== normalizedCurrent.description ||
+    normalizedInitial.category !== normalizedCurrent.category ||
+    normalizedInitial.due !== normalizedCurrent.due ||
+    normalizedInitial.location !== normalizedCurrent.location ||
+    normalizedInitial.locationLat !== normalizedCurrent.locationLat ||
+    normalizedInitial.locationLon !== normalizedCurrent.locationLon ||
+    normalizedInitial.meetingUrl !== normalizedCurrent.meetingUrl ||
+    normalizedInitial.recurrence !== normalizedCurrent.recurrence ||
+    normalizedInitial.recurMode !== normalizedCurrent.recurMode ||
+    normalizedInitial.notes !== normalizedCurrent.notes ||
+    taskPanelRemindersChanged(initialReminders, currentReminders)
+  );
+}
+
+export function mergeSavedReminderDrafts(
+  drafts: TaskPanelReminderDraft[],
+  reminders: TaskReminder[],
+): TaskPanelReminderDraft[] {
+  if (drafts.length !== reminders.length) {
+    return drafts;
+  }
+
+  return drafts.map((draft, index) =>
+    taskReminderToDraft(reminders[index], draft.clientId),
+  );
+}

--- a/tests/core/commands.test.ts
+++ b/tests/core/commands.test.ts
@@ -209,7 +209,7 @@ describe("executeCommand", () => {
     expect(result).toBe("quit: unexpected argument 'foo'");
   });
 
-  it("handles :wq command", () => {
+  it("routes :wq through the panel close flow", () => {
     let saved = false;
     let closed = false;
     const ctx = makeMockContext({
@@ -228,11 +228,11 @@ describe("executeCommand", () => {
       },
     });
     executeCommand("wq", commandRegistry, ctx);
-    expect(saved).toBe(true);
+    expect(saved).toBe(false);
     expect(closed).toBe(true);
   });
 
-  it("handles :x alias for :wq", () => {
+  it("routes :x through the panel close flow", () => {
     let saved = false;
     let closed = false;
     const ctx = makeMockContext({
@@ -251,7 +251,7 @@ describe("executeCommand", () => {
       },
     });
     executeCommand("x", commandRegistry, ctx);
-    expect(saved).toBe(true);
+    expect(saved).toBe(false);
     expect(closed).toBe(true);
   });
 

--- a/tests/core/task-detail-save.test.ts
+++ b/tests/core/task-detail-save.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createReminderEndpoint } from "@/core/reminders/endpoints";
+import { createTaskReminder, listTaskReminders } from "@/core/reminders/rules";
+import { createTask, getTask } from "@/core/task";
+import { saveTaskDetails } from "@/core/task-detail-save";
+import type { Db } from "@/core/types";
+import { createTestDb, createTestUser } from "../helpers";
+
+let db: Db;
+let userId: number;
+
+beforeEach(() => {
+  process.env.INTEGRATION_ENCRYPTION_KEY = "1".repeat(64);
+  db = createTestDb();
+  userId = createTestUser(db).id;
+});
+
+describe("saveTaskDetails", () => {
+  it("updates the task and reminder set in one call", () => {
+    const task = createTask(db, userId, { description: "Old title" });
+    const endpoint = createReminderEndpoint(db, userId, {
+      adapterKey: "telegram.bot_api",
+      label: "Telegram",
+      target: "chat-1",
+    });
+    const reminder = createTaskReminder(db, userId, {
+      taskId: task.id,
+      endpointId: endpoint.id,
+      anchor: "due",
+      offsetMinutes: -15,
+    });
+
+    const result = saveTaskDetails(db, userId, task.id, {
+      task: { description: "New title" },
+      reminders: [
+        {
+          clientId: "existing",
+          id: reminder.id,
+          endpointId: endpoint.id,
+          anchor: "start",
+          offsetMinutes: 0,
+          allDayLocalTime: null,
+          enabled: 1,
+        },
+        {
+          clientId: "created",
+          id: null,
+          endpointId: endpoint.id,
+          anchor: "due",
+          offsetMinutes: 30,
+          allDayLocalTime: null,
+          enabled: 1,
+        },
+      ],
+    });
+
+    expect(result.task.description).toBe("New title");
+    expect(result.reminders).toHaveLength(2);
+    expect(result.reminders[0].anchor).toBe("start");
+    expect(result.reminders[1].id).toBeGreaterThan(reminder.id);
+
+    const persisted = listTaskReminders(db, userId, task.id);
+    expect(persisted).toHaveLength(2);
+    expect(persisted.map((item) => item.offsetMinutes)).toEqual([0, 30]);
+  });
+
+  it("rolls back the task update when reminder validation fails", () => {
+    const task = createTask(db, userId, { description: "Original" });
+
+    expect(() =>
+      saveTaskDetails(db, userId, task.id, {
+        task: { description: "Should not persist" },
+        reminders: [
+          {
+            clientId: "broken",
+            id: null,
+            endpointId: 999,
+            anchor: "due",
+            offsetMinutes: 0,
+            allDayLocalTime: null,
+            enabled: 1,
+          },
+        ],
+      }),
+    ).toThrow("Reminder endpoint not found");
+
+    expect(getTask(db, task.id)?.description).toBe("Original");
+    expect(listTaskReminders(db, userId, task.id)).toHaveLength(0);
+  });
+});

--- a/tests/lib/task-panel-save.test.ts
+++ b/tests/lib/task-panel-save.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTaskPanelUpdateInput,
+  isTaskPanelDirty,
+  mergeSavedReminderDrafts,
+} from "@/lib/task-panel-save";
+
+describe("task panel save helpers", () => {
+  it("omits due when the user has not changed it", () => {
+    const input = buildTaskPanelUpdateInput(
+      {
+        description: "  Write tests  ",
+        category: "Work",
+        due: "2026-04-24T09:30",
+        location: "  Home office  ",
+        locationLat: 40,
+        locationLon: -73,
+        meetingUrl: "  https://meet.example/test  ",
+        recurrence: null,
+        recurMode: "scheduled",
+        notes: null,
+      },
+      "2026-04-24T09:30",
+    );
+
+    expect(input).toEqual({
+      description: "Write tests",
+      category: "Work",
+      notes: null,
+      location: "Home office",
+      locationLat: 40,
+      locationLon: -73,
+      meetingUrl: "https://meet.example/test",
+      recurrence: null,
+      recurMode: null,
+    });
+  });
+
+  it("treats trimmed text changes as already saved", () => {
+    const dirty = isTaskPanelDirty(
+      {
+        description: "Write tests",
+        category: "Work",
+        due: "2026-04-24T09:30",
+        location: "Desk",
+        locationLat: null,
+        locationLon: null,
+        meetingUrl: "",
+        recurrence: null,
+        recurMode: "scheduled",
+        notes: null,
+      },
+      {
+        description: "  Write tests  ",
+        category: "Work",
+        due: "2026-04-24T09:30",
+        location: "  Desk  ",
+        locationLat: null,
+        locationLon: null,
+        meetingUrl: "   ",
+        recurrence: null,
+        recurMode: "scheduled",
+        notes: null,
+      },
+      null,
+      null,
+    );
+
+    expect(dirty).toBe(false);
+  });
+
+  it("preserves client ids when mapping saved reminders back into drafts", () => {
+    const drafts = [
+      {
+        clientId: "draft-1",
+        id: null,
+        endpointId: 3,
+        anchor: "due" as const,
+        offsetMinutes: -15,
+        allDayLocalTime: null,
+        enabled: 1 as const,
+      },
+    ];
+
+    const merged = mergeSavedReminderDrafts(drafts, [
+      {
+        id: 8,
+        userId: 1,
+        taskId: 2,
+        endpointId: 3,
+        anchor: "due",
+        offsetMinutes: -15,
+        allDayLocalTime: null,
+        enabled: 1,
+        createdAt: "2026-04-24T00:00:00.000Z",
+        updatedAt: "2026-04-24T00:00:00.000Z",
+      },
+    ]);
+
+    expect(merged).toEqual([
+      {
+        clientId: "draft-1",
+        id: 8,
+        endpointId: 3,
+        anchor: "due",
+        offsetMinutes: -15,
+        allDayLocalTime: null,
+        enabled: 1,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- move task detail updates and reminder writes into a single server-side save action
- serialize task-panel saves and await close-triggered saves before tearing down panel state
- add task-panel save helpers and regression tests for atomic save + rollback behavior

## Test plan
- [x] `pnpm vitest run tests/lib/task-panel-save.test.ts tests/core/task-detail-save.test.ts tests/core/task.test.ts tests/api/tasks.test.ts`
- [x] `pnpm tsc --noEmit`
- [x] Manual verification by the user
